### PR TITLE
Øk max antall replika til 2

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -3,7 +3,7 @@ name: syfooppfolgingsplanservice
 team: teamsykefravr
 replicas:
   min: 1
-  max: 1
+  max: 2
   cpuThresholdPercentage: 80
 port: 8080
 healthcheck:


### PR DESCRIPTION
Dette vil forhåpentligvis lette på trykket til appen, slik at den ikke
restarter så ofte, og ved restart får vi ikke nedetid.