### PR TITLE
Legg til leader election, bare leder kjører batch, øk til 2 replicas

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -2,10 +2,11 @@ image: "repo.adeo.no:5443/syfooppfolgingsplanservice"
 name: syfooppfolgingsplanservice
 team: teamsykefravr
 replicas:
-  min: 1
-  max: 1
+  min: 2
+  max: 2
   cpuThresholdPercentage: 80
 port: 8080
+leaderElection: true
 healthcheck:
   liveness:
     path: /syfooppfolgingsplanservice/internal/isAlive

--- a/src/main/java/no/nav/syfo/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/syfo/config/ApplicationConfig.java
@@ -37,19 +37,25 @@ public class ApplicationConfig {
     }
 
     @Bean
+    @Primary
     public RestTemplate restTemplate(ClientHttpRequestInterceptor... interceptors) {
         RestTemplate template = new RestTemplate();
         template.setInterceptors(asList(interceptors));
         return template;
     }
 
+    @Bean(name = "kubernetes")
+    public RestTemplate restTemplateKubernetes() {
+        return new RestTemplate();
+    }
+
     @Bean
     FilterRegistrationBean<AuthorizationFilterFeed> feedFilter() {
-        FilterRegistrationBean<AuthorizationFilterFeed> registrationBean =  new FilterRegistrationBean<>();
+        FilterRegistrationBean<AuthorizationFilterFeed> registrationBean = new FilterRegistrationBean<>();
 
         registrationBean.setFilter(new AuthorizationFilterFeed());
         registrationBean.addUrlPatterns("/api/system/feed/*");
 
-        return  registrationBean;
+        return registrationBean;
     }
 }

--- a/src/main/java/no/nav/syfo/domain/LeaderPod.java
+++ b/src/main/java/no/nav/syfo/domain/LeaderPod.java
@@ -1,0 +1,8 @@
+package no.nav.syfo.domain;
+
+import lombok.Value;
+
+@Value
+public class LeaderPod {
+    String name;
+}

--- a/src/main/java/no/nav/syfo/scheduler/AsynkOppgaverRapportScheduledTask.java
+++ b/src/main/java/no/nav/syfo/scheduler/AsynkOppgaverRapportScheduledTask.java
@@ -4,8 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.syfo.domain.AsynkOppgave;
 import no.nav.syfo.metric.Metrikk;
 import no.nav.syfo.repository.dao.AsynkOppgaveDAO;
+import no.nav.syfo.service.LeaderElectionService;
 import no.nav.syfo.util.Toggle;
-import org.slf4j.Logger;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -24,9 +24,12 @@ public class AsynkOppgaverRapportScheduledTask {
     @Inject
     private Toggle toggle;
 
+    @Inject
+    private LeaderElectionService leaderElectionService;
+
     @Scheduled(cron = "0 0 0 * * *")
     public void run() {
-        if (toggle.toggleBatch()) {
+        if (leaderElectionService.isLeader() && toggle.toggleBatch()) {
             log.info("TRACEBATCH: run {}", this.getClass().getName());
 
             final List<AsynkOppgave> asynkOppgaver = asynkOppgaveDAO.finnOppgaver();

--- a/src/main/java/no/nav/syfo/scheduler/AsynkOppgaverScheduledTask.java
+++ b/src/main/java/no/nav/syfo/scheduler/AsynkOppgaverScheduledTask.java
@@ -1,7 +1,9 @@
 package no.nav.syfo.scheduler;
 
 import lombok.extern.slf4j.Slf4j;
+import no.nav.syfo.metric.Metrikk;
 import no.nav.syfo.oppgave.Oppgavelisteprosessor;
+import no.nav.syfo.service.LeaderElectionService;
 import no.nav.syfo.util.Toggle;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -16,9 +18,17 @@ public class AsynkOppgaverScheduledTask {
     @Inject
     private Toggle toggle;
 
-    @Scheduled(cron = "*/10 * * * * *")
+    @Inject
+    private LeaderElectionService leaderElectionService;
+
+    @Inject
+    private Metrikk metrikk;
+
+    @Scheduled(fixedRate = 2000)
     public void run() {
-        if (toggle.toggleBatch()) {
+        metrikk.tellHendelse("kanskje_AsynkOppgave");
+        if (leaderElectionService.isLeader() && toggle.toggleBatch()) {
+            metrikk.tellHendelse("kjorer_AsynkOppgave");
             log.info("TRACEBATCH: run {}", this.getClass().getName());
 
             oppgavelisteprosessor.run();

--- a/src/main/java/no/nav/syfo/scheduler/ProsesserInnkomnePlaner.java
+++ b/src/main/java/no/nav/syfo/scheduler/ProsesserInnkomnePlaner.java
@@ -22,6 +22,7 @@ public class ProsesserInnkomnePlaner {
     private BehandleSakService behandleSakService;
     private GodkjentplanDAO godkjentplanDAO;
     private JournalService journalService;
+    private LeaderElectionService leaderElectionService;
     private OppfoelingsdialogDAO oppfoelingsdialogDAO;
     private SakService sakService;
     private final Metrikk metrikk;
@@ -33,6 +34,7 @@ public class ProsesserInnkomnePlaner {
             BehandleSakService behandleSakService,
             GodkjentplanDAO godkjentplanDAO,
             JournalService journalService,
+            LeaderElectionService leaderElectionService,
             OppfoelingsdialogDAO oppfoelingsdialogDAO,
             SakService sakService,
             Metrikk metrikk,
@@ -42,6 +44,7 @@ public class ProsesserInnkomnePlaner {
         this.behandleSakService = behandleSakService;
         this.godkjentplanDAO = godkjentplanDAO;
         this.journalService = journalService;
+        this.leaderElectionService = leaderElectionService;
         this.oppfoelingsdialogDAO = oppfoelingsdialogDAO;
         this.sakService = sakService;
         this.metrikk = metrikk;
@@ -50,7 +53,7 @@ public class ProsesserInnkomnePlaner {
 
     @Scheduled(fixedRate = 60000)
     public void opprettSaker() {
-        if (toggle.toggleBatchSak()) {
+        if (leaderElectionService.isLeader() && toggle.toggleBatchSak()) {
             log.info("TRACEBATCH: run {} opprettSaker", this.getClass().getName());
 
             godkjentplanDAO.hentIkkeSaksfoertePlaner()
@@ -66,7 +69,7 @@ public class ProsesserInnkomnePlaner {
 
     @Scheduled(fixedRate = 60000)
     public void opprettJournalposter() {
-        if (!"true".equals(getProperty(LOCAL_MOCK)) && toggle.toggleBatchSak()) {
+        if (leaderElectionService.isLeader() && !"true".equals(getProperty(LOCAL_MOCK)) && toggle.toggleBatchSak()) {
             log.info("TRACEBATCH: run {} opprettJournalposter", this.getClass().getName());
 
             godkjentplanDAO.hentIkkeJournalfoertePlaner()

--- a/src/main/java/no/nav/syfo/service/LeaderElectionService.java
+++ b/src/main/java/no/nav/syfo/service/LeaderElectionService.java
@@ -1,0 +1,67 @@
+package no.nav.syfo.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.syfo.domain.LeaderPod;
+import no.nav.syfo.metric.Metrikk;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.InetAddress;
+
+@Service
+@Slf4j
+public class LeaderElectionService {
+
+    private final Metrikk metrikk;
+    private final RestTemplate restTemplateKubernetes;
+    private final String electorpath;
+
+    @Inject
+    public LeaderElectionService(
+            Metrikk metrikk,
+            @Qualifier("kubernetes") RestTemplate restTemplateKubernetes,
+            @Value("${elector.path}") String electorpath
+    ) {
+        this.metrikk = metrikk;
+        this.restTemplateKubernetes = restTemplateKubernetes;
+        this.electorpath = electorpath;
+    }
+
+    public boolean isLeader() {
+        metrikk.tellHendelse("isLeader_kalt");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String url = "http://" + electorpath;
+
+        String response = restTemplateKubernetes.getForObject(url, String.class);
+
+        try {
+            LeaderPod leader = objectMapper.readValue(response, LeaderPod.class);
+            return isHostLeader(leader);
+        } catch (IOException e) {
+            log.error("Couldn't map response from electorPath to LeaderPod object", e);
+            metrikk.tellHendelse("isLeader_feilet");
+            throw new RuntimeException("Couldn't map response from electorpath to LeaderPod object", e);
+        } catch (Exception e) {
+            log.error("Something went wrong when trying to check leader", e);
+            metrikk.tellHendelse("isLeader_feilet");
+            throw new RuntimeException("Got exception when trying to find leader", e);
+        }
+    }
+
+    private boolean isHostLeader(LeaderPod leader) throws Exception {
+        String hostName = InetAddress.getLocalHost().getHostName();
+        String leaderName = leader.getName();
+
+        if (hostName.equals(leaderName)) {
+            log.info("Host with name {} is leader", hostName);
+            return true;
+        }
+        log.info("Host with name {} is not leader {}", hostName, leaderName);
+        return false;
+    }
+}

--- a/src/test/java/no/nav/syfo/scheduler/AsynkOppgaverScheduledTaskTest.java
+++ b/src/test/java/no/nav/syfo/scheduler/AsynkOppgaverScheduledTaskTest.java
@@ -1,6 +1,8 @@
 package no.nav.syfo.scheduler;
 
+import no.nav.syfo.metric.Metrikk;
 import no.nav.syfo.oppgave.Oppgavelisteprosessor;
+import no.nav.syfo.service.LeaderElectionService;
 import no.nav.syfo.util.Toggle;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,6 +21,10 @@ public class AsynkOppgaverScheduledTaskTest {
     private Toggle toggle;
     @Mock
     private Oppgavelisteprosessor oppgavelisteprosessor;
+    @Mock
+    private LeaderElectionService leaderElectionService;
+    @Mock
+    private Metrikk metrikk;
 
     @InjectMocks
     private AsynkOppgaverScheduledTask asynkOppgaverScheduledTask;
@@ -26,6 +32,7 @@ public class AsynkOppgaverScheduledTaskTest {
     @Before
     public void setup() {
         when(toggle.toggleBatch()).thenReturn(true);
+        when(leaderElectionService.isLeader()).thenReturn(true);
     }
 
     @Test
@@ -33,5 +40,7 @@ public class AsynkOppgaverScheduledTaskTest {
         asynkOppgaverScheduledTask.run();
 
         verify(oppgavelisteprosessor).run();
+        verify(metrikk).tellHendelse("kanskje_AsynkOppgave");
+        verify(metrikk).tellHendelse("kjorer_AsynkOppgave");
     }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -26,6 +26,7 @@ srvsyfooppfolgingsplanservice:
   username: "username"
   password: "1234"
 
+elector.path: "www.kanskje.no"
 
 #no.nav.security.oidc:
 #  issuers: selvbetjening,intern


### PR DESCRIPTION
Når en scheduled task skal kjøre, hent leder-poden fra kubernetes og sjekk om den er den samme som host-podden. Hvis ja, fortsett kjøringen; hvis nei, ikke gjør noe
Bruk egen RestTemplate for spørringen til kubernetes, for å unngå problemer med tråder og context
Legg på logging av isLeader-metoden, den skal ikke feile, da man alltid skal kunne nå kubernetes, og responsen skal alltid være korrekt
Bruk 2 pods for å unngå nedetid ved deploy/restart, og gi appen litt mer spillerom før den må restartes
En bug i k8s gjør at poder som ikke er leader, får forrige (døde) leader pod når de gjør kall til endepunktet. Leader får alltid seg selv til svar; det gjør at resultatet av metoden skal være riktig likevel  
Ref. denne [github-tråden](https://github.com/kubernetes-retired/contrib/issues/2930)