### PR TITLE
Get personnavn from PDL, with token from STS

### DIFF
--- a/src/main/java/no/nav/syfo/config/cache/CacheConfig.java
+++ b/src/main/java/no/nav/syfo/config/cache/CacheConfig.java
@@ -16,6 +16,7 @@ public class CacheConfig {
     public static final String CACHENAME_AKTOR_ID = "aktoerid";
     public static final String CACHENAME_AKTOR_FNR = "aktoerfnr";
     public static final String CACHENAME_ANSATTE = "ansatte";
+    public static final String CACHENAME_PERSON_PDL = "personPdl";
 
     @Bean
     public CacheManager cacheManager() {
@@ -23,7 +24,8 @@ public class CacheConfig {
         cacheManager.setCaches(asList(
                 new ConcurrentMapCache(CACHENAME_AKTOR_ID),
                 new ConcurrentMapCache(CACHENAME_AKTOR_FNR),
-                new ConcurrentMapCache(CACHENAME_ANSATTE)
+                new ConcurrentMapCache(CACHENAME_ANSATTE),
+                new ConcurrentMapCache(CACHENAME_PERSON_PDL)
         ));
         return cacheManager;
     }

--- a/src/main/java/no/nav/syfo/pdl/PdlConsumer.java
+++ b/src/main/java/no/nav/syfo/pdl/PdlConsumer.java
@@ -1,0 +1,125 @@
+package no.nav.syfo.pdl;
+
+import no.nav.syfo.metric.Metrikk;
+import no.nav.syfo.pdl.exceptions.*;
+import no.nav.syfo.sts.StsConsumer;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static no.nav.syfo.config.cache.CacheConfig.CACHENAME_PERSON_PDL;
+import static no.nav.syfo.util.RestUtils.bearerHeader;
+import static org.slf4j.LoggerFactory.getLogger;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Service
+public class PdlConsumer {
+    private static final Logger LOG = getLogger(PdlConsumer.class);
+
+    private final Metrikk metrikk;
+    private final RestTemplate restTemplate;
+    private final StsConsumer stsConsumer;
+    private final String url;
+
+    public static final String TEMA_HEADER = "Tema";
+    public static final String ALLE_TEMA_HEADERVERDI = "GEN";
+    public static final String NAV_CONSUMER_TOKEN_HEADER = "Nav-Consumer-Token";
+
+    @Autowired
+    public PdlConsumer(
+            Metrikk metrikk,
+            RestTemplate restTemplate,
+            StsConsumer stsConsumer,
+            @Value("${pdl.url}") String url
+    ) {
+        this.metrikk = metrikk;
+        this.restTemplate = restTemplate;
+        this.stsConsumer = stsConsumer;
+        this.url = url;
+    }
+
+    @Cacheable(cacheNames = CACHENAME_PERSON_PDL, key = "#ident", condition = "#ident != null")
+    public PdlHentPerson person(String ident) {
+        metrikk.tellHendelse("call_pdl");
+
+        String query = readFileAsString("pdl/hentPerson.graphql").replace("[\n\r]", "");
+
+        HttpEntity<PdlRequest> entity = createRequestEntity(
+                new PdlRequest()
+                        .query(query)
+                        .variables(new Variables().ident(ident))
+        );
+
+        final String uriString = UriComponentsBuilder.fromHttpUrl(url).toUriString();
+
+        try {
+            ResponseEntity<PdlPersonResponse> response = restTemplate.exchange(
+                    uriString,
+                    HttpMethod.POST,
+                    entity,
+                    PdlPersonResponse.class
+            );
+            metrikk.tellHendelse("call_pdl_success");
+            PdlPersonResponse responseBody = response.getBody();
+            throwExceptionIfPDLBodyHasErrorOrIsEmpty(responseBody);
+            return responseBody.data;
+        } catch (RestClientException e) {
+            metrikk.tellHendelse("call_pdl_fail");
+            LOG.error("Error from PDL with request-url: " + url, e);
+            throw e;
+        }
+    }
+
+    private void throwExceptionIfPDLBodyHasErrorOrIsEmpty(PdlPersonResponse responseBody) {
+        if (responseBody == null) {
+            metrikk.tellHendelse("call_pdl_fail");
+            throw new EmptyPDLContent("Tried to get name of person :(");
+        }
+        if (responseBody.errors != null) {
+            metrikk.tellHendelse("call_pdl_fail");
+            throw new PDLResponseBodyContainsError(responseBody.errors.get(0).toSimplifiedString());
+        }
+        if (responseBody.data.getName() == null) {
+            metrikk.tellHendelse("call_pdl_fail");
+            throw new NameFromPDLIsNull("Tried to get name of person :( (SAD) :sadpanda:");
+        }
+    }
+
+    private HttpEntity<PdlRequest> createRequestEntity(PdlRequest request) {
+        String stsToken = stsConsumer.token();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(TEMA_HEADER, ALLE_TEMA_HEADERVERDI);
+        headers.set(AUTHORIZATION, bearerHeader(stsToken));
+        headers.set(NAV_CONSUMER_TOKEN_HEADER, bearerHeader(stsToken));
+
+        return new HttpEntity<>(request, headers);
+    }
+
+    private String readFileAsString(String path) {
+        try {
+            Resource resource = new ClassPathResource(path);
+            InputStream input = resource.getInputStream();
+
+            return IOUtils.toString(input, StandardCharsets.UTF_8.name());
+        } catch (IOException e) {
+            metrikk.tellHendelse("pdl_feil");
+            LOG.error("Feilet ved lesing av hentPerson query", e);
+            throw new RuntimeException("Feilet ved lesing av hentPerson query", e);
+        }
+    }
+}

--- a/src/main/java/no/nav/syfo/pdl/PdlError.java
+++ b/src/main/java/no/nav/syfo/pdl/PdlError.java
@@ -1,0 +1,19 @@
+package no.nav.syfo.pdl;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+@Data
+@Accessors(fluent = true)
+public class PdlError {
+    public String message;
+    public List<PdlErrorLocation> locations;
+    public List<String> path;
+    public PdlErrorExtension extensions;
+
+    public String toSimplifiedString() {
+        return message + " with code: " + extensions.code + " and classification: " + extensions.classification;
+    }
+}

--- a/src/main/java/no/nav/syfo/pdl/PdlErrorExtension.java
+++ b/src/main/java/no/nav/syfo/pdl/PdlErrorExtension.java
@@ -1,0 +1,11 @@
+package no.nav.syfo.pdl;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+public class PdlErrorExtension {
+    public String code;
+    public String classification;
+}

--- a/src/main/java/no/nav/syfo/pdl/PdlErrorLocation.java
+++ b/src/main/java/no/nav/syfo/pdl/PdlErrorLocation.java
@@ -1,0 +1,11 @@
+package no.nav.syfo.pdl;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+public class PdlErrorLocation {
+    public int line;
+    public int column;
+}

--- a/src/main/java/no/nav/syfo/pdl/PdlHentPerson.java
+++ b/src/main/java/no/nav/syfo/pdl/PdlHentPerson.java
@@ -1,0 +1,39 @@
+package no.nav.syfo.pdl;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+import org.slf4j.Logger;
+
+import java.util.List;
+
+import static no.nav.syfo.util.StringUtil.lowerCapitalize;
+import static org.slf4j.LoggerFactory.getLogger;
+
+@Data
+@Accessors(fluent = true)
+public class PdlHentPerson {
+    private static final Logger LOG = getLogger(PdlPerson.class);
+
+    public PdlPerson hentPerson;
+
+    public String getName() {
+        if (hentPerson == null) {
+            return null;
+        }
+        List<PdlPersonNavn> nameList = hentPerson.navn;
+        if (nameList == null || nameList.isEmpty()) {
+            return null;
+        }
+
+        PdlPersonNavn personNavn = nameList.get(0);
+        String firstName = lowerCapitalize(personNavn.fornavn);
+        String middleName = personNavn.mellomnavn;
+        String surName = lowerCapitalize(personNavn.etternavn);
+
+        if (middleName == null || middleName.isEmpty()) {
+            return firstName + " " + surName;
+        } else {
+            return firstName + " " + lowerCapitalize(middleName) + " " + surName;
+        }
+    }
+}

--- a/src/main/java/no/nav/syfo/pdl/PdlPerson.java
+++ b/src/main/java/no/nav/syfo/pdl/PdlPerson.java
@@ -1,0 +1,12 @@
+package no.nav.syfo.pdl;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+@Data
+@Accessors(fluent = true)
+public class PdlPerson {
+    public List<PdlPersonNavn> navn;
+}

--- a/src/main/java/no/nav/syfo/pdl/PdlPersonNavn.java
+++ b/src/main/java/no/nav/syfo/pdl/PdlPersonNavn.java
@@ -1,0 +1,12 @@
+package no.nav.syfo.pdl;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+public class PdlPersonNavn {
+    public String fornavn;
+    public String mellomnavn;
+    public String etternavn;
+}

--- a/src/main/java/no/nav/syfo/pdl/PdlPersonResponse.java
+++ b/src/main/java/no/nav/syfo/pdl/PdlPersonResponse.java
@@ -1,0 +1,13 @@
+package no.nav.syfo.pdl;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+@Data
+@Accessors(fluent = true)
+public class PdlPersonResponse {
+    public List<PdlError> errors;
+    public PdlHentPerson data;
+}

--- a/src/main/java/no/nav/syfo/pdl/PdlRequest.java
+++ b/src/main/java/no/nav/syfo/pdl/PdlRequest.java
@@ -1,0 +1,13 @@
+package no.nav.syfo.pdl;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+@JsonSerialize
+public class PdlRequest {
+    public String query;
+    public Variables variables;
+}

--- a/src/main/java/no/nav/syfo/pdl/Variables.java
+++ b/src/main/java/no/nav/syfo/pdl/Variables.java
@@ -1,0 +1,13 @@
+package no.nav.syfo.pdl;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+@JsonSerialize
+public class Variables {
+    public String ident;
+    public boolean navnHistorikk = false;
+}

--- a/src/main/java/no/nav/syfo/pdl/exceptions/EmptyPDLContent.java
+++ b/src/main/java/no/nav/syfo/pdl/exceptions/EmptyPDLContent.java
@@ -1,0 +1,7 @@
+package no.nav.syfo.pdl.exceptions;
+
+public class EmptyPDLContent extends RuntimeException {
+    public EmptyPDLContent(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/no/nav/syfo/pdl/exceptions/NameFromPDLIsNull.java
+++ b/src/main/java/no/nav/syfo/pdl/exceptions/NameFromPDLIsNull.java
@@ -1,0 +1,7 @@
+package no.nav.syfo.pdl.exceptions;
+
+public class NameFromPDLIsNull extends RuntimeException {
+    public NameFromPDLIsNull(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/no/nav/syfo/pdl/exceptions/PDLResponseBodyContainsError.java
+++ b/src/main/java/no/nav/syfo/pdl/exceptions/PDLResponseBodyContainsError.java
@@ -1,0 +1,7 @@
+package no.nav.syfo.pdl.exceptions;
+
+public class PDLResponseBodyContainsError extends RuntimeException{
+    public PDLResponseBodyContainsError(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/no/nav/syfo/sts/StsConsumer.java
+++ b/src/main/java/no/nav/syfo/sts/StsConsumer.java
@@ -1,0 +1,78 @@
+package no.nav.syfo.sts;
+
+import no.nav.syfo.metric.Metrikk;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import static no.nav.syfo.sts.StsToken.setExpirationTime;
+import static no.nav.syfo.util.RestUtils.basicCredentials;
+import static org.slf4j.LoggerFactory.getLogger;
+
+@Service
+public class StsConsumer {
+    private static final Logger LOG = getLogger(StsConsumer.class);
+
+    private final Metrikk metrikk;
+    private final String password;
+    private final RestTemplate restTemplate;
+    private final String url;
+    private final String username;
+
+    private StsToken cachedOidcToken = null;
+
+    @Autowired
+    public StsConsumer(
+            Metrikk metrikk,
+            @Value("${srv.password}") String password,
+            RestTemplate restTemplate,
+            @Value("${security.token.service.rest.url}") String url,
+            @Value("${srv.username}") String username
+    ) {
+        this.metrikk = metrikk;
+        this.password = password;
+        this.restTemplate = restTemplate;
+        this.url = url;
+        this.username = username;
+    }
+
+    public String token() {
+        if (StsToken.shouldRenew(cachedOidcToken)) {
+            metrikk.tellHendelse("call_sts");
+
+            HttpEntity request = new HttpEntity<>(authorizationHeader());
+
+            try {
+                ResponseEntity<StsToken> response = restTemplate.exchange(
+                        getStsTokenUrl(),
+                        HttpMethod.GET,
+                        request,
+                        StsToken.class
+                );
+                StsToken token = response.getBody();
+                setExpirationTime(token);
+                cachedOidcToken = response.getBody();
+                metrikk.tellHendelse("call_sts_success");
+            } catch (HttpClientErrorException e) {
+                metrikk.tellHendelse("call_sts_fail");
+                throw e;
+            }
+        }
+        return cachedOidcToken.access_token;
+    }
+
+    private String getStsTokenUrl() {
+        return url + "/rest/v1/sts/token?grant_type=client_credentials&scope=openid";
+    }
+
+    private HttpHeaders authorizationHeader() {
+        String credentials = basicCredentials(username, password);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, credentials);
+        return headers;
+    }
+}

--- a/src/main/java/no/nav/syfo/sts/StsToken.java
+++ b/src/main/java/no/nav/syfo/sts/StsToken.java
@@ -1,0 +1,34 @@
+package no.nav.syfo.sts;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.time.LocalDateTime;
+
+@Data
+@Accessors(fluent = true)
+public class StsToken {
+    public String access_token;
+    public String token_type;
+    public int expires_in;
+
+    LocalDateTime expirationTime;
+
+    public static void setExpirationTime(StsToken token) {
+        if (token == null) {
+            return;
+        }
+        token.expirationTime = LocalDateTime.now().plusSeconds(token.expires_in - 10L);
+    }
+
+    public static boolean shouldRenew(StsToken token) {
+        if (token == null) {
+            return true;
+        }
+        return isExpired(token);
+    }
+
+    private static boolean isExpired(StsToken token) {
+        return token.expirationTime.isBefore(LocalDateTime.now());
+    }
+}

--- a/src/main/java/no/nav/syfo/util/StringUtil.java
+++ b/src/main/java/no/nav/syfo/util/StringUtil.java
@@ -1,0 +1,9 @@
+package no.nav.syfo.util;
+
+import org.apache.commons.lang.StringUtils;
+
+public class StringUtil {
+    public static String lowerCapitalize(String input) {
+        return StringUtils.capitalize(input.toLowerCase());
+    }
+}

--- a/src/main/resources/pdl/hentPerson.graphql
+++ b/src/main/resources/pdl/hentPerson.graphql
@@ -1,0 +1,15 @@
+query($ident: ID!, $navnHistorikk: Boolean!){
+  hentPerson(ident: $ident) {
+  	navn(historikk: $navnHistorikk) {
+  	  fornavn
+  	  mellomnavn
+  	  etternavn
+  	  forkortetNavn
+  	  originaltNavn {
+  	    fornavn
+  	    mellomnavn
+  	    etternavn
+  	  }
+    }
+  }
+}

--- a/src/test/java/no/nav/syfo/api/selvbetjening/controller/ArbeidsgiverOppfolgingsplanControllerTest.java
+++ b/src/test/java/no/nav/syfo/api/selvbetjening/controller/ArbeidsgiverOppfolgingsplanControllerTest.java
@@ -4,6 +4,7 @@ import no.nav.syfo.api.intern.ressurs.AbstractRessursTilgangTest;
 import no.nav.syfo.api.selvbetjening.domain.RSOpprettOppfoelgingsdialog;
 import no.nav.syfo.metric.Metrikk;
 import no.nav.syfo.narmesteleder.NarmesteLederConsumer;
+import no.nav.syfo.pdl.*;
 import no.nav.syfo.service.OppfoelgingsdialogService;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,12 +13,15 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import javax.inject.Inject;
 import javax.ws.rs.ForbiddenException;
 
+import java.util.Collections;
+
 import static no.nav.syfo.api.selvbetjening.domain.BrukerkontekstConstant.ARBEIDSGIVER;
 import static no.nav.syfo.mocks.AktoerMock.mockAktorId;
 import static no.nav.syfo.testhelper.OidcTestHelper.loggInnBruker;
 import static no.nav.syfo.testhelper.OidcTestHelper.loggUtAlle;
 import static no.nav.syfo.testhelper.UserConstants.*;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +33,8 @@ public class ArbeidsgiverOppfolgingsplanControllerTest extends AbstractRessursTi
     OppfoelgingsdialogService oppfoelgingsdialogService;
     @MockBean
     Metrikk metrikk;
+    @MockBean
+    PdlConsumer pdlConsumer;
 
     @Inject
     private ArbeidsgiverOppfolgingsplanController arbeidsgiverOppfolgingsplanController;
@@ -36,6 +42,7 @@ public class ArbeidsgiverOppfolgingsplanControllerTest extends AbstractRessursTi
     @Before
     public void setup() {
         loggInnBruker(oidcRequestContextHolder, LEDER_FNR);
+        when(pdlConsumer.person(anyString())).thenReturn(new PdlHentPerson().hentPerson(new PdlPerson().navn(Collections.singletonList(new PdlPersonNavn().fornavn("Fornavn").mellomnavn("MellomNavn").etternavn("etternavn")))));
     }
 
     @Test

--- a/src/test/java/no/nav/syfo/pdl/PdlConsumerTest.java
+++ b/src/test/java/no/nav/syfo/pdl/PdlConsumerTest.java
@@ -1,0 +1,144 @@
+package no.nav.syfo.pdl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.syfo.LocalApplication;
+import no.nav.syfo.metric.Metrikk;
+import no.nav.syfo.pdl.exceptions.*;
+import no.nav.syfo.sts.StsConsumer;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.inject.Inject;
+
+import static java.util.Collections.singletonList;
+import static no.nav.syfo.pdl.PdlConsumer.*;
+import static no.nav.syfo.util.RestUtils.bearerHeader;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = LocalApplication.class)
+@DirtiesContext
+public class PdlConsumerTest {
+    @MockBean
+    private Metrikk metrikk;
+    @Inject
+    private RestTemplate restTemplate;
+    @MockBean
+    private StsConsumer stsConsumer;
+
+    @Value("${pdl.url}")
+    private String url;
+
+    @Inject
+    private PdlConsumer pdlConsumer;
+
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Before
+    public void setUp() {
+        this.mockRestServiceServer = MockRestServiceServer.bindTo(restTemplate).build();
+        when(stsConsumer.token()).thenReturn("token");
+    }
+
+    @After
+    public void tearDown() {
+        mockRestServiceServer.verify();
+    }
+
+    @Test
+    public void person_returns_correct_name() {
+        PdlHentPerson expectedPdlHentPerson = new PdlHentPerson()
+                .hentPerson(new PdlPerson()
+                        .navn(singletonList(new PdlPersonNavn()
+                                .fornavn("Fornavn")
+                                .mellomnavn("Mellomnavn")
+                                .etternavn("Etternavn"))
+                        )
+                );
+
+        PdlPersonResponse pdlPersonResponse = new PdlPersonResponse()
+                .errors(null)
+                .data(expectedPdlHentPerson);
+
+        mockResponseFromPDL(pdlPersonResponse);
+
+        PdlHentPerson result = pdlConsumer.person("321");
+
+        assertThat(result.getName()).isEqualTo(expectedPdlHentPerson.getName());
+    }
+
+    @Test(expected = EmptyPDLContent.class)
+    public void exception_when_empty_responseBody_from_pdl() {
+        mockResponseFromPDL(null);
+
+        pdlConsumer.person("123");
+    }
+
+    @Test(expected = PDLResponseBodyContainsError.class)
+    public void exception_when_errors_in_responseBody() {
+        PdlError error = new PdlError()
+                .message("Fant ikke person")
+                .extensions(new PdlErrorExtension()
+                        .code("not_found")
+                        .classification("ExecutionAborted"));
+
+        PdlPersonResponse pdlPersonResponse = new PdlPersonResponse()
+                .errors(singletonList(error))
+                .data(new PdlHentPerson().hentPerson(null));
+
+        mockResponseFromPDL(pdlPersonResponse);
+
+        pdlConsumer.person("123");
+    }
+
+    @Test(expected = NameFromPDLIsNull.class)
+    public void exception_when_getName_returns_null() {
+        PdlPersonResponse pdlPersonResponse = new PdlPersonResponse()
+                .errors(null)
+                .data(new PdlHentPerson().hentPerson(null));
+
+        mockResponseFromPDL(pdlPersonResponse);
+
+        pdlConsumer.person("123");
+    }
+
+    private void mockResponseFromPDL(PdlPersonResponse pdlPersonResponse) {
+        String responseBody = pdlResponseAsJsonString(pdlPersonResponse);
+
+        String token = stsConsumer.token();
+
+        final String uriString = UriComponentsBuilder.fromHttpUrl(url).toUriString();
+        mockRestServiceServer.expect(once(), requestTo(uriString))
+                .andExpect(method(POST))
+                .andExpect(header(TEMA_HEADER, ALLE_TEMA_HEADERVERDI))
+                .andExpect(header(AUTHORIZATION, bearerHeader(token)))
+                .andExpect(header(NAV_CONSUMER_TOKEN_HEADER, bearerHeader(token)))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+    }
+
+    private String pdlResponseAsJsonString(PdlPersonResponse response) {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            return objectMapper.writeValueAsString(response);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/no/nav/syfo/pdl/PdlHentPersonTest.java
+++ b/src/test/java/no/nav/syfo/pdl/PdlHentPersonTest.java
@@ -1,0 +1,69 @@
+package no.nav.syfo.pdl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PdlHentPersonTest {
+    @Test
+    public void full_name_without_middlename() {
+        PdlHentPerson pdlHentPerson = mockPdlHentPerson(null);
+
+        String name = pdlHentPerson.getName();
+
+        assertThat(name.split(" ").length).isEqualTo(2);
+        assertThat(name).isEqualTo("Fornavn Etternavn");
+    }
+
+    @Test
+    public void full_name_with_middleName() {
+        PdlHentPerson pdlHentPerson = mockPdlHentPerson("Mellomnavn");
+
+        String name = pdlHentPerson.getName();
+
+        assertThat(name.split(" ").length).isEqualTo(3);
+        assertThat(name).isEqualTo("Fornavn Mellomnavn Etternavn");
+    }
+
+    @Test
+    public void null_when_hentPerson_is_null() {
+        PdlHentPerson pdlHentPerson = new PdlHentPerson().hentPerson(null);
+
+        String name = pdlHentPerson.getName();
+
+        assertThat(name).isNull();
+    }
+
+    @Test
+    public void null_when_PdlPersonNavnList_is_null() {
+        PdlHentPerson pdlHentPerson = new PdlHentPerson().hentPerson(new PdlPerson().navn(null));
+
+        String name = pdlHentPerson.getName();
+
+        assertThat(name).isNull();
+    }
+
+    @Test
+    public void null_when_PdlPersonNavnList_is_empty() {
+        PdlHentPerson pdlHentPerson = new PdlHentPerson().hentPerson(new PdlPerson().navn(emptyList()));
+
+        String name = pdlHentPerson.getName();
+
+        assertThat(name).isNull();
+    }
+
+    private PdlHentPerson mockPdlHentPerson(String middleName) {
+        return new PdlHentPerson()
+                .hentPerson(new PdlPerson()
+                        .navn(singletonList(new PdlPersonNavn()
+                                .fornavn("Fornavn")
+                                .mellomnavn(middleName)
+                                .etternavn("Etternavn"))
+                        ));
+    }
+}

--- a/src/test/java/no/nav/syfo/sts/StsConsumerTest.java
+++ b/src/test/java/no/nav/syfo/sts/StsConsumerTest.java
@@ -1,0 +1,101 @@
+package no.nav.syfo.sts;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.syfo.LocalApplication;
+import no.nav.syfo.metric.Metrikk;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.inject.Inject;
+
+import static no.nav.syfo.util.RestUtils.basicCredentials;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = LocalApplication.class)
+@DirtiesContext
+public class StsConsumerTest {
+    @MockBean
+    private Metrikk metrikk;
+    @Value("${srv.password}")
+    private String password;
+    @Inject
+    private RestTemplate restTemplate;
+
+    @Value("${security.token.service.rest.url}")
+    private String url;
+    @Value("${srv.username}")
+    private String username;
+
+    @Inject
+    private StsConsumer stsConsumer;
+
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Before
+    public void setUp() {
+        this.mockRestServiceServer = MockRestServiceServer.bindTo(restTemplate).build();
+    }
+
+    @After
+    public void tearDown() {
+        mockRestServiceServer.verify();
+    }
+
+    @Test
+    public void token_returns_correct_token_and_cached_token() {
+        StsToken expectedToken = new StsToken()
+                .access_token("token")
+                .token_type("type")
+                .expires_in(3600);
+
+        mockResponseFromSTS(expectedToken);
+
+        String result = stsConsumer.token();
+        String result2 = stsConsumer.token();
+
+        assertThat(result).isEqualTo(expectedToken.access_token);
+        assertThat(result2).isEqualTo(expectedToken.access_token);
+
+    }
+
+    private void mockResponseFromSTS(StsToken stsToken) {
+        String credentials = basicCredentials(username, password);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, credentials);
+
+        String responseBody = stsTokenAsJsonString(stsToken);
+
+        final String uriString = UriComponentsBuilder.fromHttpUrl(url + "/rest/v1/sts/token?grant_type=client_credentials&scope=openid").toUriString();
+        mockRestServiceServer.expect(once(), requestTo(uriString))
+                .andExpect(method(GET))
+                .andExpect(header(AUTHORIZATION, credentials))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+    }
+
+    private String stsTokenAsJsonString(StsToken stsToken) {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            return objectMapper.writeValueAsString(stsToken);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -48,6 +48,7 @@ lagrejuridisklogg.rest.url: "juridisklogg-lagre.url"
 sykefravaersoppfoelging.v1.endpointurl: "sykefravaeroppfoelgingv1.url"
 syfonarmesteleder.url: "syfonarmesteleder.url"
 syfonarmesteleder.id: "syfonarmestelederID"
+pdl.url: "https://pdl.url"
 virksomhet:
   arbeidsfordeling.v1.endpointurl: "arbeidsfordelingv1.url"
   arbeidsforhold.v3.endpointurl: "arbeidsforhold.url"
@@ -64,6 +65,7 @@ virksomhet:
   sak.v1.endpointurl: "sak.url"
 
 ad.accesstoken.url: 'accesstoken.url'
+security.token.service.rest.url: "http://security-token-service.url"
 
 nais.cluster.name: 'local'
 environment.name: 'dev'


### PR DESCRIPTION
Hent person fra PDL, basert på ident (PDL godtar både fnr og aktørID, men for at det skal fungere i preprod, må vi bruke fnr).
Siden PDL bruker GraphQL, kan vi få 200 OK selv om kallet feilet; derfor trengs det en ekstra sjekk på hva innholdet i responsen er (om error-listen er tom eller ikke, og om navn faktisk er der).
Bruk STS-token for å autentisere oss mot PDL.
STS-tokenet bruker en egen cache, siden TTL ikke nødvendigvis følger sykelen til "vanlig" cache.