### PR TITLE
Add new Gradering STRENGT_FORTROLIG_UTLAND in Adressebekyttelse

### DIFF
--- a/src/main/kotlin/no/nav/syfo/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/PdlPersonResponse.kt
@@ -45,6 +45,7 @@ data class Adressebeskyttelse(
 ) : Serializable
 
 enum class Gradering : Serializable {
+    STRENGT_FORTROLIG_UTLAND,
     STRENGT_FORTROLIG,
     FORTROLIG,
     UGRADERT
@@ -56,9 +57,17 @@ fun PdlHentPerson.isKode6Or7(): Boolean {
         false
     } else {
         return adressebeskyttelse.any {
-            it.gradering == Gradering.STRENGT_FORTROLIG || it.gradering == Gradering.FORTROLIG
+            it.isKode6() || it.isKode7()
         }
     }
+}
+
+fun Adressebeskyttelse.isKode6(): Boolean {
+    return this.gradering == Gradering.STRENGT_FORTROLIG || this.gradering == Gradering.STRENGT_FORTROLIG_UTLAND
+}
+
+fun Adressebeskyttelse.isKode7(): Boolean {
+    return this.gradering == Gradering.FORTROLIG
 }
 
 fun PdlHentPerson.fullName(): String? {


### PR DESCRIPTION
STRENGT_FORTROLIG_UTLAND should be treatet the same as STRENGT_FORTROLIG, i.e. as a Kode6