### PR TITLE
Use max 1 decimal in stillingsprosent

### DIFF
--- a/src/main/java/no/nav/syfo/aareg/AaregConsumer.java
+++ b/src/main/java/no/nav/syfo/aareg/AaregConsumer.java
@@ -15,11 +15,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static no.nav.syfo.aareg.AaregUtils.stillingsprosentWithMaxScale;
 import static no.nav.syfo.aareg.OpplysningspliktigArbeidsgiver.Type.Organisasjon;
 import static no.nav.syfo.util.RestUtils.bearerHeader;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -90,7 +90,7 @@ public class AaregConsumer {
                 .flatMap(arbeidsforhold -> arbeidsforhold.arbeidsavtaler().stream())
                 .map(arbeidsavtale -> new Stilling()
                         .yrke(arbeidsavtale.yrke)
-                        .prosent(new BigDecimal(arbeidsavtale.stillingsprosent)))
+                        .prosent(stillingsprosentWithMaxScale(arbeidsavtale.stillingsprosent)))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/no/nav/syfo/aareg/AaregUtils.java
+++ b/src/main/java/no/nav/syfo/aareg/AaregUtils.java
@@ -1,0 +1,17 @@
+package no.nav.syfo.aareg;
+
+import java.math.BigDecimal;
+
+import static java.math.RoundingMode.HALF_UP;
+
+public class AaregUtils {
+    public static BigDecimal stillingsprosentWithMaxScale(double percent) {
+        BigDecimal percentAsBigDecimal = new BigDecimal(percent);
+
+        if (percentAsBigDecimal.scale() > 1) {
+            return percentAsBigDecimal.setScale(1, HALF_UP);
+        }
+
+        return percentAsBigDecimal;
+    }
+}

--- a/src/test/java/no/nav/syfo/aareg/AaregConsumerTest.java
+++ b/src/test/java/no/nav/syfo/aareg/AaregConsumerTest.java
@@ -18,10 +18,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.*;
 
+import static no.nav.syfo.aareg.AaregUtils.stillingsprosentWithMaxScale;
 import static no.nav.syfo.aareg.utils.AaregConsumerTestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -145,6 +145,6 @@ public class AaregConsumerTest {
         Stilling stilling = stillingList.get(0);
 
         assertThat(stilling.yrke).isEqualTo(YRKESKODE);
-        assertThat(stilling.prosent).isEqualTo(new BigDecimal(STILLINGSPROSENT));
+        assertThat(stilling.prosent).isEqualTo(stillingsprosentWithMaxScale(STILLINGSPROSENT));
     }
 }


### PR DESCRIPTION
Hvis det er et helt tall, legger vi ikke til ekstra 0'er.
Obs: BigDecimal.setScale() returnerer en ny BigDecimal, siden BigDecimal er immutable