### PR TITLE
Get stillingsnavn from kode, from Felles Kodeverk

### DIFF
--- a/src/main/java/no/nav/syfo/aareg/AaregConsumer.java
+++ b/src/main/java/no/nav/syfo/aareg/AaregConsumer.java
@@ -1,5 +1,6 @@
 package no.nav.syfo.aareg;
 
+import no.nav.syfo.fellesKodeverk.FellesKodeverkConsumer;
 import no.nav.syfo.aareg.exceptions.RestErrorFromAareg;
 import no.nav.syfo.aktorregister.AktorregisterConsumer;
 import no.nav.syfo.metric.Metrikk;
@@ -30,6 +31,7 @@ public class AaregConsumer {
     private static final Logger LOG = getLogger(AaregConsumer.class);
 
     private final AktorregisterConsumer aktorregisterConsumer;
+    private final FellesKodeverkConsumer fellesKodeverkConsumer;
     private final Metrikk metrikk;
     private final RestTemplate restTemplate;
     private final StsConsumer stsConsumer;
@@ -41,12 +43,14 @@ public class AaregConsumer {
     @Autowired
     public AaregConsumer(
             AktorregisterConsumer aktorregisterConsumer,
+            FellesKodeverkConsumer fellesKodeverkConsumer,
             Metrikk metrikk,
             RestTemplate restTemplate,
             StsConsumer stsConsumer,
             @Value("${aareg.services.url}") String url
     ) {
         this.aktorregisterConsumer = aktorregisterConsumer;
+        this.fellesKodeverkConsumer = fellesKodeverkConsumer;
         this.metrikk = metrikk;
         this.restTemplate = restTemplate;
         this.stsConsumer = stsConsumer;
@@ -89,7 +93,7 @@ public class AaregConsumer {
                 .filter(arbeidsforhold -> arbeidsforhold.ansettelsesperiode.periode.tom == null || !tilLocalDate(arbeidsforhold.ansettelsesperiode.periode.tom).isBefore(fom))
                 .flatMap(arbeidsforhold -> arbeidsforhold.arbeidsavtaler().stream())
                 .map(arbeidsavtale -> new Stilling()
-                        .yrke(arbeidsavtale.yrke)
+                        .yrke(fellesKodeverkConsumer.stillingsnavnFromKode(arbeidsavtale.yrke))
                         .prosent(stillingsprosentWithMaxScale(arbeidsavtale.stillingsprosent)))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/no/nav/syfo/config/CacheConfig.java
+++ b/src/main/java/no/nav/syfo/config/CacheConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.*;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,6 +22,7 @@ public class CacheConfig {
     public static final String CACHENAME_LEDER = "leder";
     public static final String CACHENAME_ARBEIDSFORHOLD_AT = "arbeidsforholdAT";
     public static final String CACHENAME_TILGANG_TIL_IDENT = "tilgangtilident";
+    public static final String CACHENAME_FELLESKODEVERK_BETYDNINGER = "felleskodeverkBetydninger";
 
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
@@ -37,6 +39,7 @@ public class CacheConfig {
         cacheConfigurations.put(CACHENAME_LEDER, defaultConfig);
         cacheConfigurations.put(CACHENAME_ARBEIDSFORHOLD_AT, defaultConfig);
         cacheConfigurations.put(CACHENAME_TILGANG_TIL_IDENT, defaultConfig);
+        cacheConfigurations.put(CACHENAME_FELLESKODEVERK_BETYDNINGER, defaultConfig);
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig())

--- a/src/main/java/no/nav/syfo/fellesKodeverk/Beskrivelse.java
+++ b/src/main/java/no/nav/syfo/fellesKodeverk/Beskrivelse.java
@@ -1,0 +1,11 @@
+package no.nav.syfo.fellesKodeverk;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+public class Beskrivelse {
+    public String tekst;
+    public String term;
+}

--- a/src/main/java/no/nav/syfo/fellesKodeverk/Betydning.java
+++ b/src/main/java/no/nav/syfo/fellesKodeverk/Betydning.java
@@ -1,0 +1,14 @@
+package no.nav.syfo.fellesKodeverk;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.Map;
+
+@Data
+@Accessors(fluent = true)
+public class Betydning {
+    public Map<String, Beskrivelse> beskrivelser;
+    public String gyldigFra;
+    public String gyldigTil;
+}

--- a/src/main/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumer.java
+++ b/src/main/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumer.java
@@ -1,0 +1,84 @@
+package no.nav.syfo.fellesKodeverk;
+
+import no.nav.syfo.fellesKodeverk.exceptions.MissingStillingsnavn;
+import no.nav.syfo.metric.Metrikk;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import static no.nav.syfo.config.CacheConfig.CACHENAME_FELLESKODEVERK_BETYDNINGER;
+import static no.nav.syfo.util.RequestUtilKt.APP_CONSUMER_ID;
+import static no.nav.syfo.util.RequestUtilKt.createCallId;
+import static org.apache.commons.lang.StringUtils.capitalize;
+import static org.slf4j.LoggerFactory.getLogger;
+import static org.springframework.http.HttpMethod.GET;
+
+@Service
+public class FellesKodeverkConsumer {
+    private static final Logger LOG = getLogger(FellesKodeverkConsumer.class);
+
+    private final Metrikk metric;
+    private final RestTemplate restTemplate;
+    private final String url;
+
+    public static final String NAV_CALL_ID_HEADER = "Nav-Call-Id";
+    public static final String NAV_CONSUMER_ID = "Nav-Consumer-Id";
+
+    @Autowired
+    public FellesKodeverkConsumer(
+            Metrikk metric,
+            RestTemplate restTemplate,
+            @Value("${felleskodeverk.url}") String url
+    ) {
+        this.metric = metric;
+        this.restTemplate = restTemplate;
+        this.url = url;
+    }
+
+    @Cacheable(cacheNames = CACHENAME_FELLESKODEVERK_BETYDNINGER)
+    public KodeverkKoderBetydningerResponse kodeverkKoderBetydninger() {
+        String kodeverkYrkerBetydningUrl = url + "/kodeverk/Yrker/koder/betydninger?spraak=nb";
+
+        try {
+            ResponseEntity<KodeverkKoderBetydningerResponse> response = restTemplate.exchange(
+                    kodeverkYrkerBetydningUrl,
+                    GET,
+                    entity(),
+                    KodeverkKoderBetydningerResponse.class
+            );
+            metric.tellHendelse("call_felleskodeverk_success");
+            return response.getBody();
+        } catch (RestClientException e) {
+            metric.tellHendelse("call_felleskodeverk_fail");
+            LOG.error("Error from Felles Kodeverk with request-url: " + kodeverkYrkerBetydningUrl, e);
+            throw new RuntimeException("Tried to get kodeBetydninger from Felles Kodeverk", e);
+        }
+    }
+
+    public String stillingsnavnFromKode(String stillingskode) {
+        KodeverkKoderBetydningerResponse response = kodeverkKoderBetydninger();
+        try {
+            String stillingsnavn = stillingsnavnFromKodeverkKoderBetydningerResponse(response, stillingskode);
+            return capitalize(stillingsnavn);
+        } catch (NullPointerException e) {
+            LOG.error("Couldn't find navn for stillingskode!");
+            throw new MissingStillingsnavn("Didn't get stillingsnavn for stillingskode: " + stillingskode, e);
+        }
+    }
+
+    private String stillingsnavnFromKodeverkKoderBetydningerResponse(KodeverkKoderBetydningerResponse response, String stillingskode) {
+        return response.betydninger.get(stillingskode).get(0).beskrivelser.get("nb").tekst;
+    }
+
+    private HttpEntity entity() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(NAV_CALL_ID_HEADER, createCallId());
+        headers.add(NAV_CONSUMER_ID, APP_CONSUMER_ID);
+        return new HttpEntity<>(headers);
+    }
+}

--- a/src/main/java/no/nav/syfo/fellesKodeverk/KodeverkKoderBetydningerResponse.java
+++ b/src/main/java/no/nav/syfo/fellesKodeverk/KodeverkKoderBetydningerResponse.java
@@ -1,0 +1,13 @@
+package no.nav.syfo.fellesKodeverk;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Accessors(fluent = true)
+public class KodeverkKoderBetydningerResponse {
+    public Map<String, List<Betydning>> betydninger;
+}

--- a/src/main/java/no/nav/syfo/fellesKodeverk/exceptions/MissingStillingsnavn.java
+++ b/src/main/java/no/nav/syfo/fellesKodeverk/exceptions/MissingStillingsnavn.java
@@ -1,0 +1,7 @@
+package no.nav.syfo.fellesKodeverk.exceptions;
+
+public class MissingStillingsnavn extends RuntimeException {
+    public MissingStillingsnavn(String message, Exception e) {
+        super(message, e);
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.util
 import java.util.*
 
 const val NAV_CONSUMER_ID_HEADER = "Nav-Consumer-Id"
-const val APP_CONSUMER_ID = "syfooppfolgingsplanservice"
+const val APP_CONSUMER_ID = "srvsyfooppfolgings"
 const val NAV_CALL_ID_HEADER = "Nav-Call-Id"
 
 const val NAV_CONSUMER_TOKEN_HEADER = "Nav-Consumer-Token"

--- a/src/test/java/no/nav/syfo/aareg/AaregConsumerTest.java
+++ b/src/test/java/no/nav/syfo/aareg/AaregConsumerTest.java
@@ -1,5 +1,6 @@
 package no.nav.syfo.aareg;
 
+import no.nav.syfo.fellesKodeverk.FellesKodeverkConsumer;
 import no.nav.syfo.aareg.exceptions.RestErrorFromAareg;
 import no.nav.syfo.aktorregister.AktorregisterConsumer;
 import no.nav.syfo.metric.Metrikk;
@@ -35,6 +36,8 @@ public class AaregConsumerTest {
     @Mock
     private AktorregisterConsumer aktorregisterConsumer;
     @Mock
+    private FellesKodeverkConsumer fellesKodeverkConsumer;
+    @Mock
     private Metrikk metrikk;
     @Mock
     private RestTemplate restTemplate;
@@ -50,6 +53,7 @@ public class AaregConsumerTest {
     public void setup() {
         ReflectionTestUtils.setField(aaregConsumer, "url", AAREG_URL);
         when(stsConsumer.token()).thenReturn("token");
+        when(fellesKodeverkConsumer.stillingsnavnFromKode(anyString())).thenReturn(YRKESNAVN);
     }
 
     @Test
@@ -144,7 +148,7 @@ public class AaregConsumerTest {
 
         Stilling stilling = stillingList.get(0);
 
-        assertThat(stilling.yrke).isEqualTo(YRKESKODE);
+        assertThat(stilling.yrke).isEqualTo(YRKESNAVN);
         assertThat(stilling.prosent).isEqualTo(stillingsprosentWithMaxScale(STILLINGSPROSENT));
     }
 }

--- a/src/test/java/no/nav/syfo/aareg/utils/AaregConsumerTestUtils.java
+++ b/src/test/java/no/nav/syfo/aareg/utils/AaregConsumerTestUtils.java
@@ -13,7 +13,8 @@ public class AaregConsumerTestUtils {
     public static final String AT_FNR = "12345678901";
     public static final LocalDate VALID_DATE = LocalDate.now().plusMonths(1);
     public static final LocalDate PASSED_DATE = LocalDate.of(1970, 1, 2);
-    public static final String YRKESKODE = "yrkeskode";
+    public static final String YRKESKODE = "1234567";
+    public static final String YRKESNAVN = "yrkesnavn";
     public static final Double STILLINGSPROSENT = 50.0;
 
     public static Arbeidsforhold simpleArbeidsforhold() {

--- a/src/test/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumerTest.java
+++ b/src/test/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumerTest.java
@@ -1,0 +1,131 @@
+package no.nav.syfo.fellesKodeverk;
+
+import junit.framework.TestCase;
+import no.nav.syfo.fellesKodeverk.exceptions.MissingStillingsnavn;
+import no.nav.syfo.metric.Metrikk;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpStatus.OK;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FellesKodeverkConsumerTest extends TestCase {
+    @Mock
+    private Metrikk metric;
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private FellesKodeverkConsumer fellesKodeverkConsumer;
+
+    private static final String STILLINGSNAVN = "Special Agent";
+    private static final String WRONG_STILLINGSNAVN = "Deputy Director";
+    private static final String STILLINGSKODE = "1234567";
+    private static final String WRONG_STILLINGSKODE = "9876543";
+    private static final String SPRAK = "nb";
+
+    @Test
+    public void stillingsnavnFromKode_gives_correct_stillingsnavn() {
+        KodeverkKoderBetydningerResponse expectedResponse = responseBody();
+        when(restTemplate.exchange(anyString(), eq(GET), any(HttpEntity.class), eq(KodeverkKoderBetydningerResponse.class))).thenReturn(new ResponseEntity<>(expectedResponse, OK));
+
+        String actualStillingsnavn = fellesKodeverkConsumer.stillingsnavnFromKode(STILLINGSKODE);
+
+        assertThat(actualStillingsnavn).isEqualTo(STILLINGSNAVN);
+
+        verify(metric).tellHendelse("call_felleskodeverk_success");
+    }
+
+    @Test(expected = MissingStillingsnavn.class)
+    public void stillingsnavnFromKode_throws_exception_if_navn_not_found() {
+        KodeverkKoderBetydningerResponse expectedResponse = responseBodyWithWrongKode();
+        when(restTemplate.exchange(anyString(), eq(GET), any(HttpEntity.class), eq(KodeverkKoderBetydningerResponse.class))).thenReturn(new ResponseEntity<>(expectedResponse, OK));
+
+        fellesKodeverkConsumer.stillingsnavnFromKode(STILLINGSKODE);
+
+        verify(metric).tellHendelse("call_felleskodeverk_success");
+    }
+
+    @Test
+    public void get_kodeverkKoderBetydninger() {
+        KodeverkKoderBetydningerResponse expectedResponse = responseBody();
+        when(restTemplate.exchange(anyString(), eq(GET), any(HttpEntity.class), eq(KodeverkKoderBetydningerResponse.class))).thenReturn(new ResponseEntity<>(expectedResponse, OK));
+
+        KodeverkKoderBetydningerResponse actualResponse = fellesKodeverkConsumer.kodeverkKoderBetydninger();
+
+        assertThat(actualResponse.betydninger.get(STILLINGSKODE)).isNotNull();
+        assertThat(actualResponse.betydninger.get(STILLINGSKODE).get(0).beskrivelser.get(SPRAK)).isNotNull();
+        assertThat(actualResponse.betydninger.get(STILLINGSKODE).get(0).beskrivelser.get(SPRAK).tekst).isEqualTo(STILLINGSNAVN);
+
+        verify(metric).tellHendelse("call_felleskodeverk_success");
+    }
+
+
+    @Test
+    public void kodeverKoderBetydninger_fail() {
+        when(restTemplate.exchange(anyString(), eq(GET), any(HttpEntity.class), eq(KodeverkKoderBetydningerResponse.class))).thenThrow(new RestClientException("Something went wrong!"));
+
+        try {
+            fellesKodeverkConsumer.kodeverkKoderBetydninger();
+        } catch (Exception e) {
+            verify(metric).tellHendelse("call_felleskodeverk_fail");
+            assertThat(e.getClass()).isEqualTo(RuntimeException.class);
+            assertThat(e.getMessage()).isEqualTo("Tried to get kodeBetydninger from Felles Kodeverk");
+        }
+    }
+
+    private KodeverkKoderBetydningerResponse responseBody() {
+        Beskrivelse beskrivelse = new Beskrivelse()
+                .tekst(STILLINGSNAVN)
+                .term(STILLINGSNAVN);
+
+        Map<String, Beskrivelse> beskrivelser = new HashMap<>();
+        beskrivelser.put(SPRAK, beskrivelse);
+
+        Betydning betydning = new Betydning()
+                .beskrivelser(beskrivelser)
+                .gyldigFra(new Date().toString())
+                .gyldigTil(new Date().toString());
+
+        Map<String, List<Betydning>> betydninger = new HashMap<>();
+        betydninger.put(STILLINGSKODE, singletonList(betydning));
+
+        return new KodeverkKoderBetydningerResponse()
+                .betydninger(betydninger);
+    }
+
+    private KodeverkKoderBetydningerResponse responseBodyWithWrongKode() {
+        Beskrivelse beskrivelse = new Beskrivelse()
+                .tekst(WRONG_STILLINGSNAVN)
+                .term(WRONG_STILLINGSNAVN);
+
+        Map<String, Beskrivelse> beskrivelser = new HashMap<>();
+        beskrivelser.put(SPRAK, beskrivelse);
+
+        Betydning betydning = new Betydning()
+                .beskrivelser(beskrivelser)
+                .gyldigFra(new Date().toString())
+                .gyldigTil(new Date().toString());
+
+        Map<String, List<Betydning>> betydninger = new HashMap<>();
+        betydninger.put(WRONG_STILLINGSKODE, singletonList(betydning));
+
+        return new KodeverkKoderBetydningerResponse()
+                .betydninger(betydninger);
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -61,6 +61,7 @@ virksomhet:
   organisasjonressursenhet.v1.endpointurl: "organisasjonRessursEnhetv1.url"
   sak.v1.endpointurl: "sak.url"
 dokarkiv.url: "http://dokarkiv.url"
+felleskodeverk.url: "http://kodeverk.url"
 
 syfobehandlendeenhet.url: "http://syfobehandlendeenhet"
 ad.accesstoken.url: 'accesstoken.url'


### PR DESCRIPTION
Når man skal hente stillinger for en sykmeldt, gjør om stillingskoden man får fra aareg-services, til navn på stillingen, slik at det vises riktig i oppfølgingsplanen i sykmeldt enkeltperson