### PR TITLE
Make all stillingsnavn capitalized

### DIFF
--- a/src/main/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumer.java
+++ b/src/main/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumer.java
@@ -14,7 +14,7 @@ import org.springframework.web.client.RestTemplate;
 import static no.nav.syfo.config.CacheConfig.CACHENAME_FELLESKODEVERK_BETYDNINGER;
 import static no.nav.syfo.util.RequestUtilKt.APP_CONSUMER_ID;
 import static no.nav.syfo.util.RequestUtilKt.createCallId;
-import static org.apache.commons.lang.StringUtils.capitalize;
+import static no.nav.syfo.util.StringUtilKt.lowerCapitalize;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.http.HttpMethod.GET;
 
@@ -64,7 +64,7 @@ public class FellesKodeverkConsumer {
         KodeverkKoderBetydningerResponse response = kodeverkKoderBetydninger();
         try {
             String stillingsnavn = stillingsnavnFromKodeverkKoderBetydningerResponse(response, stillingskode);
-            return capitalize(stillingsnavn);
+            return lowerCapitalize(stillingsnavn);
         } catch (NullPointerException e) {
             LOG.error("Couldn't find navn for stillingskode!");
             throw new MissingStillingsnavn("Didn't get stillingsnavn for stillingskode: " + stillingskode, e);

--- a/src/main/java/no/nav/syfo/pdf/domain/StillingXML.java
+++ b/src/main/java/no/nav/syfo/pdf/domain/StillingXML.java
@@ -1,9 +1,7 @@
 package no.nav.syfo.pdf.domain;
 
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.*;
 import java.math.BigDecimal;
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -19,7 +17,7 @@ public class StillingXML {
     public BigDecimal prosent;
 
     public StillingXML withYrke(String yrke) {
-        this.yrke = yrke.toLowerCase();
+        this.yrke = yrke;
         return this;
     }
 

--- a/src/test/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumerTest.java
+++ b/src/test/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumerTest.java
@@ -34,6 +34,7 @@ public class FellesKodeverkConsumerTest extends TestCase {
     private FellesKodeverkConsumer fellesKodeverkConsumer;
 
     private static final String STILLINGSNAVN = "Special Agent";
+    private static final String STILLINGSNAVN_LOWERCAPITALIZED = "Special agent";
     private static final String WRONG_STILLINGSNAVN = "Deputy Director";
     private static final String STILLINGSKODE = "1234567";
     private static final String WRONG_STILLINGSKODE = "9876543";
@@ -46,7 +47,7 @@ public class FellesKodeverkConsumerTest extends TestCase {
 
         String actualStillingsnavn = fellesKodeverkConsumer.stillingsnavnFromKode(STILLINGSKODE);
 
-        assertThat(actualStillingsnavn).isEqualTo(STILLINGSNAVN);
+        assertThat(actualStillingsnavn).isEqualTo(STILLINGSNAVN_LOWERCAPITALIZED);
 
         verify(metric).tellHendelse("call_felleskodeverk_success");
     }


### PR DESCRIPTION
Her var det noe som konverterte alt til små bokstaver, nå blir første bokstav stor uansett, resten blir små.