### PR TITLE
Add flyway-script to delete invalid Godkjenninger

### DIFF
--- a/src/main/resources/db/migration/V1_24__delete_invalid_godkjenninger_from_person_with_self_as_leader.sql
+++ b/src/main/resources/db/migration/V1_24__delete_invalid_godkjenninger_from_person_with_self_as_leader.sql
@@ -1,0 +1,15 @@
+DELETE
+FROM GODKJENNING go
+WHERE go.OPPFOELGINGSDIALOG_ID IN (
+    SELECT go.OPPFOELGINGSDIALOG_ID
+    FROM GODKJENNING go JOIN (
+        SELECT *
+        FROM (
+                 SELECT AKTOER_ID as aktorF, OPPFOELGINGSDIALOG_ID AS oid, count(AKTOER_ID) AS countF
+                 FROM GODKJENNING
+                 GROUP BY AKTOER_ID, OPPFOELGINGSDIALOG_ID
+             )
+        WHERE  countF > 1
+    )
+    ON go.OPPFOELGINGSDIALOG_ID = oid
+);


### PR DESCRIPTION
Persons who are their own leader are not supposed to be allowed to create a Godkjenning. Functionality to prevent this is now in place, and this script will delete Godkjenning-entries submitted by person in this category.