### PR TITLE
Increase trigger threshold and range vector length

### DIFF
--- a/alerts.yaml
+++ b/alerts.yaml
@@ -17,14 +17,14 @@ spec:
       action: "Undersøk hvofor {{ $labels.app }} er nede i prod-fss"
       severity: danger
     - alert: HIGH RATIO OF HTTP 5XX RESPONSE
-      expr: (100 * (sum by (backend) (rate(traefik_backend_requests_total{code=~"^5\\d\\d", backend=~"syfooppfolgingsplanservice.nais.adeo..+"}[3m])) / sum by (backend) (rate(traefik_backend_requests_total{backend=~"syfooppfolgingsplanservice.nais.adeo..+"}[3m])))) > 1
-      for: 3m
+      expr: (100 * (sum by (backend) (rate(traefik_backend_requests_total{code=~"^5\\d\\d", backend=~"syfooppfolgingsplanservice.nais.adeo..+"}[5m])) / sum by (backend) (rate(traefik_backend_requests_total{backend=~"syfooppfolgingsplanservice.nais.adeo..+"}[5m])))) > 2
+      for: 5m
       description: "App {{ $labels.app }} har en høy andel 500 feil {{ $labels.kubernetes_namespace }}"
       action: "Sjekk i Grafana eller logger at {{ $labels.backend }} returnerer mange 500-feil"
       severity: danger
     - alert: HIGH RATIO OF HTTP 4XX RESPONSE
-      expr: (100 * (sum by (backend) (rate(traefik_backend_requests_total{code=~"^5\\d\\d", backend=~"syfooppfolgingsplanservice.nais.adeo..+"}[3m])) / sum by (backend) (rate(traefik_backend_requests_total{backend=~"syfooppfolgingsplanservice.nais.adeo..+"}[3m])))) > 10
-      for: 3m
+      expr: (100 * (sum by (backend) (rate(traefik_backend_requests_total{code=~"^5\\d\\d", backend=~"syfooppfolgingsplanservice.nais.adeo..+"}[5m])) / sum by (backend) (rate(traefik_backend_requests_total{backend=~"syfooppfolgingsplanservice.nais.adeo..+"}[5m])))) > 10
+      for: 5m
       description: "App {{ $labels.app }} har en høy 400 feil {{ $labels.kubernetes_namespace }}"
       action: "Sjekk i Grafana eller logger at {{ $labels.backend }} returnerer mange 400-feil"
       severity: warning


### PR DESCRIPTION
The triggers for alerterator are a little bit sensitive and may be set too low. The apps' (somewhat high) error rate causes the triggers to fire during normal circumstances. Increasing these values should therefore lead to less noise and more reliable alerting.