### PR TITLE
Fix missing name of stillingskode in kodeverk

### DIFF
--- a/src/main/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumer.java
+++ b/src/main/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumer.java
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
 import static no.nav.syfo.config.CacheConfig.CACHENAME_FELLESKODEVERK_BETYDNINGER;
 import static no.nav.syfo.util.RequestUtilKt.APP_CONSUMER_ID;
 import static no.nav.syfo.util.RequestUtilKt.createCallId;
@@ -66,8 +69,8 @@ public class FellesKodeverkConsumer {
             String stillingsnavn = stillingsnavnFromKodeverkKoderBetydningerResponse(response, stillingskode);
             return lowerCapitalize(stillingsnavn);
         } catch (NullPointerException e) {
-            LOG.error("Couldn't find navn for stillingskode!");
-            throw new MissingStillingsnavn("Didn't get stillingsnavn for stillingskode: " + stillingskode, e);
+            LOG.error("Couldn't find navn for stillingskode: " + stillingskode);
+            return "Ugyldig yrkeskode " + stillingskode;
         }
     }
 

--- a/src/test/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumerTest.java
+++ b/src/test/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumerTest.java
@@ -1,7 +1,6 @@
 package no.nav.syfo.fellesKodeverk;
 
 import junit.framework.TestCase;
-import no.nav.syfo.fellesKodeverk.exceptions.MissingStillingsnavn;
 import no.nav.syfo.metric.Metrikk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,12 +51,14 @@ public class FellesKodeverkConsumerTest extends TestCase {
         verify(metric).tellHendelse("call_felleskodeverk_success");
     }
 
-    @Test(expected = MissingStillingsnavn.class)
-    public void stillingsnavnFromKode_throws_exception_if_navn_not_found() {
+    @Test
+    public void stillingsnavnFromKode_return_custom_message_if_navn_not_found() {
         KodeverkKoderBetydningerResponse expectedResponse = responseBodyWithWrongKode();
         when(restTemplate.exchange(anyString(), eq(GET), any(HttpEntity.class), eq(KodeverkKoderBetydningerResponse.class))).thenReturn(new ResponseEntity<>(expectedResponse, OK));
 
-        fellesKodeverkConsumer.stillingsnavnFromKode(STILLINGSKODE);
+        String actualStillingsnavn = fellesKodeverkConsumer.stillingsnavnFromKode(STILLINGSKODE);
+
+        assertThat(actualStillingsnavn).isEqualTo("Ugyldig yrkeskode " + STILLINGSKODE);
 
         verify(metric).tellHendelse("call_felleskodeverk_success");
     }


### PR DESCRIPTION
Certain Stillingskoder i AAreg are faulty and Stillingnavn will therefore not be returned from Kodeverk. An attempt to complete an approved Oppfolgingsplan for a Arbeidstaker that has a faulty Stillingskode results in a thrown exception preventing completion of the Oppfolgingsplan. This quick fix return a string with the Stillingskode and a description.