### PR TITLE
Set version of oauth2-oidc-sdk explicitly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ object Versions {
     const val cxfVersion = "3.3.7"
     const val flywayVersion = "5.1.4"
     const val kotlinJacksonVersion = "2.9.8"
+    const val nimbusSDKVersion = "7.0.3"
     const val oidcSupportVersion = "0.2.18"
     const val ojdbc8Version = "19.3.0.0"
     const val helseXmlVersion = "1.5d21db9"
@@ -109,6 +110,7 @@ dependencies {
 
     implementation("org.apache.httpcomponents:httpclient:4.5.6")
 
+    implementation("com.nimbusds:oauth2-oidc-sdk:${Versions.nimbusSDKVersion}")
     implementation("no.nav.security:oidc-spring-support:${Versions.oidcSupportVersion}")
     testImplementation("no.nav.security:oidc-test-support:${Versions.oidcSupportVersion}")
 


### PR DESCRIPTION
This is to prevent open ended range import of nimbus-jose-jwt and automatic import of faulty version.