### PR TITLE
Add handling Diskresjonskode 6/7 for Oppfolgingsplan from LPS

### DIFF
--- a/src/main/kotlin/no/nav/syfo/altinnkanal/AltinnKanalKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/altinnkanal/AltinnKanalKafkaConsumer.kt
@@ -56,6 +56,7 @@ class AltinnKanalKafkaConsumer @Inject constructor(
 
             log.info("KAFKA-TRACE(LPS): Lagrer LPS-plan i DB with reference ${consumerRecord.value().getArchiveReference()}")
             val virksomhetsnummer = Virksomhetsnummer(skjemainnhold.arbeidsgiver.orgnr)
+
             oppfolgingsplanLPSService.receivePlan(
                 consumerRecord.value().getArchiveReference(),
                 recordBatch,

--- a/src/main/kotlin/no/nav/syfo/lps/OppfolgingsplanLPSService.kt
+++ b/src/main/kotlin/no/nav/syfo/lps/OppfolgingsplanLPSService.kt
@@ -4,12 +4,12 @@ import no.nav.helse.op2016.Skjemainnhold
 import no.nav.syfo.domain.FeiletSending
 import no.nav.syfo.domain.Fodselsnummer
 import no.nav.syfo.domain.Virksomhetsnummer
-import no.nav.syfo.lps.database.OppfolgingsplanLPSDAO
-import no.nav.syfo.lps.database.POppfolgingsplanLPS
-import no.nav.syfo.lps.database.mapToOppfolgingsplanLPS
+import no.nav.syfo.lps.database.*
 import no.nav.syfo.lps.kafka.OppfolgingsplanLPSNAVProducer
 import no.nav.syfo.metric.Metrikk
 import no.nav.syfo.oppfolgingsplan.avro.KOppfolgingsplanLPSNAV
+import no.nav.syfo.pdl.PdlConsumer
+import no.nav.syfo.pdl.isKode6Or7
 import no.nav.syfo.service.FastlegeService
 import no.nav.syfo.service.FeiletSendingService
 import no.nav.syfo.service.JournalforOPService
@@ -28,7 +28,9 @@ class OppfolgingsplanLPSService @Inject constructor(
     private val oppfolgingsplanLPSNAVProducer: OppfolgingsplanLPSNAVProducer,
     private val metrikk: Metrikk,
     private val oppfolgingsplanLPSDAO: OppfolgingsplanLPSDAO,
+    private val oppfolgingsplanLPSRetryDAO: OppfolgingsplanLPSRetryDAO,
     private val opPdfGenConsumer: OPPdfGenConsumer,
+    private val pdlConsumer: PdlConsumer,
     private val feiletSendingService: FeiletSendingService
 ) {
     private val log = LoggerFactory.getLogger(OppfolgingsplanLPSService::class.java)
@@ -56,12 +58,6 @@ class OppfolgingsplanLPSService @Inject constructor(
         skjemainnhold: Skjemainnhold,
         virksomhetsnummer: Virksomhetsnummer
     ) {
-        val idList: Pair<Long, UUID> = savePlan(
-            batch,
-            skjemainnhold,
-            virksomhetsnummer
-        )
-
         val incomingMetadata = IncomingMetadata(
             archiveReference = archiveReference,
             senderOrgName = skjemainnhold.arbeidsgiver.orgnavn,
@@ -69,25 +65,52 @@ class OppfolgingsplanLPSService @Inject constructor(
             userPersonNumber = skjemainnhold.sykmeldtArbeidstaker.fnr
         )
 
-        val lpsPdfModel = mapFormdataToFagmelding(skjemainnhold, incomingMetadata)
-        val pdf = opPdfGenConsumer.pdfgenResponse(lpsPdfModel)
-        oppfolgingsplanLPSDAO.updatePdf(idList.first, pdf)
-        log.info("KAFKA-trace: pdf generated and stored")
-
-        if (skjemainnhold.mottaksInformasjon.isOppfolgingsplanSendesTiNav == true) {
-            val kOppfolgingsplanLPSNAV = KOppfolgingsplanLPSNAV(
-                idList.second.toString(),
-                incomingMetadata.userPersonNumber,
-                virksomhetsnummer.value,
-                lpsPdfModel.oppfolgingsplan.isBehovForBistandFraNAV(),
-                LocalDate.now().toEpochDay().toInt()
+        val isUserDiskresjonsmerket = pdlConsumer.person(incomingMetadata.userPersonNumber)?.isKode6Or7()
+        if (isUserDiskresjonsmerket == null) {
+            saveLPSPlanRetry(incomingMetadata.archiveReference, batch)
+            log.warn("Diskresjonskode was not received from PDL and LPS-plan was stored in retry table.")
+            metrikk.tellHendelse("lps_plan_retry_created")
+        } else if (isUserDiskresjonsmerket) {
+            log.warn("Received Oppfolgingsplan from LPS for a person that is denied access to Oppfolgingsplan")
+            metrikk.tellHendelse("lps_plan_diskresjonsmerket")
+            return
+        } else {
+            val idList: Pair<Long, UUID> = savePlan(
+                batch,
+                skjemainnhold,
+                virksomhetsnummer
             )
-            metrikk.tellHendelseMedTag("lps_plan_behov_for_bistand_fra_nav", "bistand",  lpsPdfModel.oppfolgingsplan.isBehovForBistandFraNAV())
-            oppfolgingsplanLPSNAVProducer.sendOppfolgingsLPSTilNAV(kOppfolgingsplanLPSNAV)
+
+            val lpsPdfModel = mapFormdataToFagmelding(skjemainnhold, incomingMetadata)
+            val pdf = opPdfGenConsumer.pdfgenResponse(lpsPdfModel)
+            oppfolgingsplanLPSDAO.updatePdf(idList.first, pdf)
+            log.info("KAFKA-trace: pdf generated and stored")
+
+            if (skjemainnhold.mottaksInformasjon.isOppfolgingsplanSendesTiNav == true) {
+                val kOppfolgingsplanLPSNAV = KOppfolgingsplanLPSNAV(
+                    idList.second.toString(),
+                    incomingMetadata.userPersonNumber,
+                    virksomhetsnummer.value,
+                    lpsPdfModel.oppfolgingsplan.isBehovForBistandFraNAV(),
+                    LocalDate.now().toEpochDay().toInt()
+                )
+                metrikk.tellHendelseMedTag("lps_plan_behov_for_bistand_fra_nav", "bistand",  lpsPdfModel.oppfolgingsplan.isBehovForBistandFraNAV())
+                oppfolgingsplanLPSNAVProducer.sendOppfolgingsLPSTilNAV(kOppfolgingsplanLPSNAV)
+            }
+            if (skjemainnhold.mottaksInformasjon.isOppfolgingsplanSendesTilFastlege == true) {
+                sendLpsOppfolgingsplanTilFastlege(incomingMetadata.userPersonNumber, pdf, idList.first, 0)
+            }
         }
-        if (skjemainnhold.mottaksInformasjon.isOppfolgingsplanSendesTilFastlege == true) {
-            sendLpsOppfolgingsplanTilFastlege(incomingMetadata.userPersonNumber, pdf, idList.first, 0)
-        }
+    }
+
+    private fun saveLPSPlanRetry(
+        archiveReference: String,
+        xml: String
+    ): Long {
+        return oppfolgingsplanLPSRetryDAO.create(
+            archiveReference = archiveReference,
+            xml = xml
+        )
     }
 
     private fun savePlan(

--- a/src/main/kotlin/no/nav/syfo/lps/database/OppfolgingsplanLPSRetryDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/lps/database/OppfolgingsplanLPSRetryDAO.kt
@@ -1,0 +1,48 @@
+package no.nav.syfo.lps.database
+
+import no.nav.syfo.repository.DbUtil
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.jdbc.core.support.SqlLobValue
+import org.springframework.stereotype.Repository
+import java.sql.Types
+import java.time.LocalDateTime
+import javax.inject.Inject
+
+@Repository
+class OppfolgingsplanLPSRetryDAO @Inject constructor(
+    private val jdbcTemplate: JdbcTemplate,
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate
+) {
+    fun create(
+        archiveReference: String,
+        xml: String
+    ): Long {
+        val id = DbUtil.nesteSekvensverdi("OPPFOLGINGSPLANLPS_RETRY_ID_SEQ", jdbcTemplate)
+        val query = """
+            INSERT INTO OPPFOLGINGSPLANLPS_RETRY (
+                oppfolgingsplanlps_retry_id,
+                archive_reference,
+                xml,
+                opprettet
+            )
+            VALUES (
+                :oppfolgingsplanlpsRetryId,
+                :archiveReference,
+                :xml,
+                :opprettet
+            )
+            """.trimIndent()
+
+        val created = DbUtil.convert(LocalDateTime.now())
+
+        val mapSaveSql = MapSqlParameterSource()
+            .addValue("oppfolgingsplanlpsRetryId", id)
+            .addValue("archiveReference", archiveReference)
+            .addValue("xml", SqlLobValue(xml), Types.CLOB)
+            .addValue("opprettet", created)
+        namedParameterJdbcTemplate.update(query, mapSaveSql)
+        return id
+    }
+}

--- a/src/main/resources/db/migration/V1_32__add_table_oppfolgingsplanlps_retry.sql
+++ b/src/main/resources/db/migration/V1_32__add_table_oppfolgingsplanlps_retry.sql
@@ -1,0 +1,16 @@
+-- ROLLBACK-START
+------------------
+-- DROP SEQUENCE OPPFOLGINGSPLANLPS_RETRY_ID_SEQ;
+-- DROP TABLE OPPFOLGINGSPLANLPS_RETRY;
+---------------
+-- ROLLBACK-END
+
+CREATE SEQUENCE OPPFOLGINGSPLANLPS_RETRY_ID_SEQ START WITH 1 INCREMENT BY 1;
+
+CREATE TABLE OPPFOLGINGSPLANLPS_RETRY (
+  oppfolgingsplanlps_retry_id       NUMBER(19, 0) NOT NULL,
+  archive_reference                 VARCHAR(40) NOT NULL,
+  xml                               CLOB NOT NULL,
+  opprettet                         TIMESTAMP NOT NULL,
+  CONSTRAINT OPPFOLGINGSPLANLPS_RETRY_PK PRIMARY KEY (oppfolgingsplanlps_retry_id)
+);


### PR DESCRIPTION
- Skip and do not save or process Oppfolgingsplaner for person with Diskresjonskode
-  If PDL for some reason does not respond with a successful response for the Adressebeskyttelse of a person, then the Oppfolgingsplan from LPS i store a a retry-table in the database to enable the try of processing the Oppfolgingsplan at a later point in time.