### PR TITLE
XCy3ROHo: Setter minumum antall pods til 3

### DIFF
--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -27,7 +27,7 @@ spec:
       cpu: 1000m
       memory: 2048Mi
   replicas:
-    min: 2
+    min: 3
     max: 4
     cpuThresholdPercentage: 80
   prometheus:


### PR DESCRIPTION
Teorien er at dersom nodene får problemer med å kommunisere med hverandre kan en ny runde med leader election føre til at begge podene erklærer seg som leder som videre fører til at de leser parallelt fra tabellen med asynkrone oppgaver før en av instansene rekker å slette raden. Da vil 2 planer sendes til Altinn. Å sette minimum replica til 3 er ingen garanti, siden flere pods kan schedules på samme node, men vil minke risikoen for at de inntreffer til vi har en bedre løsning på plass