### PR TITLE
Add error handling of HttpMediaTypeNotAcceptableException

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/exception/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/syfo/api/exception/ControllerExceptionHandler.kt
@@ -18,6 +18,7 @@ import javax.ws.rs.NotFoundException;
 
 import org.slf4j.LoggerFactory.getLogger;
 import org.springframework.web.HttpMediaTypeNotAcceptableException
+import org.springframework.web.HttpRequestMethodNotSupportedException
 
 @ControllerAdvice
 class ControllerExceptionHandler @Inject constructor(private val metrikk: Metrikk) {
@@ -33,6 +34,7 @@ class ControllerExceptionHandler @Inject constructor(private val metrikk: Metrik
     private val UNAUTHORIZED_MSG = "Autorisasjonsfeil"
     private val NOT_FOUND_MSG = "Fant ikke ressurs"
     private val NOT_ACCEPTABLE_MSG = "Uakseptabelt"
+    private val METHOD_NOT_ALLOWED_MSG = "Metode ikke tillatt"
 
     @ExceptionHandler(
             Exception::class,
@@ -42,7 +44,8 @@ class ControllerExceptionHandler @Inject constructor(private val metrikk: Metrik
             IllegalArgumentException::class,
             JwtTokenUnauthorizedException::class,
             NotFoundException::class,
-            HttpMediaTypeNotAcceptableException::class
+            HttpMediaTypeNotAcceptableException::class,
+            HttpRequestMethodNotSupportedException::class
     )
     fun handleException(ex: Exception, request: WebRequest) : ResponseEntity<ApiError> {
         return when (ex) {
@@ -54,6 +57,7 @@ class ControllerExceptionHandler @Inject constructor(private val metrikk: Metrik
             is NotFoundException ->             { handleNotFoundException(ex, request) }
             is ConflictException ->             { handleConflictException(ex, request) }
             is HttpMediaTypeNotAcceptableException -> { handleHttpMediaTypeNotAcceptableException(ex, request)}
+            is HttpRequestMethodNotSupportedException -> { handleHttpRequestMethodNotSupportedException(ex, request)}
             else ->                             { handleExceptionInternal(ex, ApiError(INTERNAL_SERVER_ERROR.value(), INTERNAL_MSG), INTERNAL_SERVER_ERROR, request) }
         }
     }
@@ -88,6 +92,10 @@ class ControllerExceptionHandler @Inject constructor(private val metrikk: Metrik
 
     private fun handleHttpMediaTypeNotAcceptableException(ex: HttpMediaTypeNotAcceptableException, request: WebRequest) : ResponseEntity<ApiError> {
         return handleExceptionInternal(ex, ApiError(HttpStatus.NOT_ACCEPTABLE.value(), NOT_ACCEPTABLE_MSG), HttpStatus.NOT_ACCEPTABLE, request)
+    }
+
+    private fun handleHttpRequestMethodNotSupportedException(ex: HttpRequestMethodNotSupportedException, request: WebRequest) : ResponseEntity<ApiError> {
+        return handleExceptionInternal(ex, ApiError(HttpStatus.METHOD_NOT_ALLOWED.value(), METHOD_NOT_ALLOWED_MSG), HttpStatus.METHOD_NOT_ALLOWED, request)
     }
 
     private fun handleExceptionInternal(ex: Exception, body: ApiError, status: HttpStatus, request: WebRequest) : ResponseEntity<ApiError> {


### PR DESCRIPTION
I loggene opptrer det en del feil av typen "Uventet feil: class org.springframework.web.HttpMediaTypeNotAcceptableException : Could not find acceptable representation" og "Uventet feil: class org.springframework.web.HttpRequestMethodNotSupportedException : Request method 'GET' not supported"

Dette skyldes web crawlere som sender feil accept content type eller bruker feil request metode. Disse får pr i dag http status kode 500. Med denne fiksen så vil slike request heller få 406 Not Acceptable eller 405 Method not allowed som er riktig å bruke. I tillegg vil ikke dette lenger logges som error, men warning, da vil det heller ikke forstyrre error-loggen.