### PR TITLE
Remove unused endpoint

### DIFF
--- a/src/main/java/no/nav/syfo/api/selvbetjening/controller/DokumentController.java
+++ b/src/main/java/no/nav/syfo/api/selvbetjening/controller/DokumentController.java
@@ -78,31 +78,4 @@ public class DokumentController {
         }
     }
 
-    @GetMapping(path = "/pdfurler")
-    public List<String> hentPdfurler(@PathVariable("oppfolgingsplanId") Long oppfolgingsplanId) {
-        String innloggetIdent = getSubjectEksternMedThrows(contextHolder);
-
-        byte[] pdf = pdfService.hentPdf(oppfolgingsplanId, innloggetIdent);
-
-        int antallSiderIDokument = pdfService.hentAntallSiderIDokument(pdf);
-
-
-        String sideBaseUrl = hentSyfoapiUrl(envName) + "/syfooppfolgingsplanservice/api/dokument/" + oppfolgingsplanId + "/side/";
-
-        List<String> pdfurler = new ArrayList<>();
-        for (int i = 1; i < antallSiderIDokument + 1; i++) {
-            pdfurler.add(sideBaseUrl + i);
-        }
-
-        metrikk.tellHendelse("hent_pdfurler");
-
-        return pdfurler;
-    }
-
-    String hentSyfoapiUrl(String env) {
-        boolean erDev = env.contains("dev-fss");
-
-        String envTekst = erDev ? "-q" : "";
-        return "https://syfoapi" + envTekst + ".nav.no";
-    }
 }

--- a/src/test/kotlin/no/nav/syfo/api/selvbetjening/controller/DokumentControllerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/selvbetjening/controller/DokumentControllerTest.kt
@@ -72,48 +72,6 @@ class DokumentControllerTest : AbstractRessursTilgangTest() {
         }
     }
 
-    @Test
-    fun hentPdfurler_som_bruker() {
-        val pdf = ByteArray(10)
-        val sideantall = 3
-        Mockito.`when`(pdfService.hentPdf(oppfolgingsplanId, ARBEIDSTAKER_FNR)).thenReturn(pdf)
-        Mockito.`when`(pdfService.hentAntallSiderIDokument(pdf)).thenReturn(sideantall)
-        val returnertListe = dokumentController.hentPdfurler(oppfolgingsplanId)
-        val forventetUrl = "https://syfoapi.nav.no/syfooppfolgingsplanservice/api/dokument/$oppfolgingsplanId/side/"
-        Mockito.verify(metrikk).tellHendelse("hent_pdfurler")
-        Assert.assertEquals(sideantall.toLong(), returnertListe.size.toLong())
-        for (i in 0 until sideantall) {
-            Assert.assertEquals(forventetUrl + (i + 1), returnertListe[i])
-        }
-    }
-
-    @Test(expected = RuntimeException::class)
-    fun finner_ikke_innlogget_bruker_hentPdfurler() {
-        loggUtAlle(contextHolder)
-        dokumentController.hentPdfurler(oppfolgingsplanId)
-    }
-
-    @Test
-    fun hentSyfoapiUrl_default() {
-        val returnertVerdi = dokumentController.hentSyfoapiUrl("")
-        val forventetVerdi = "https://syfoapi.nav.no"
-        Assert.assertEquals(forventetVerdi, returnertVerdi)
-    }
-
-    @Test
-    fun hentSyfoapiUrl_prod() {
-        val returnertVerdi = dokumentController.hentSyfoapiUrl("prod-fss")
-        val forventetVerdi = "https://syfoapi.nav.no"
-        Assert.assertEquals(forventetVerdi, returnertVerdi)
-    }
-
-    @Test
-    fun hentSyfoapiUrl_preprod() {
-        val returnertVerdi = dokumentController.hentSyfoapiUrl("dev-fss")
-        val forventetVerdi = "https://syfoapi-q.nav.no"
-        Assert.assertEquals(forventetVerdi, returnertVerdi)
-    }
-
     companion object {
         private const val oppfolgingsplanId = 1L
         private const val sideId = 1L


### PR DESCRIPTION
The endpoint was previously used by oppfolgingsplan and oppfolgingsplanarbeidsgiver, but is no longer used. Remove this as part of the process to eliminate syfoapi