### PR TITLE
New endpoint for querying OP on fnr

### DIFF
--- a/src/main/java/no/nav/syfo/service/OppfolgingsplanService.java
+++ b/src/main/java/no/nav/syfo/service/OppfolgingsplanService.java
@@ -115,7 +115,7 @@ public class OppfolgingsplanService {
                 .findFirst()
                 .orElse(null);
         
-        if (ansatt == null || !tilgangskontrollService.erNaermesteLederForSykmeldt(lederFnr, ansattFnr, ansatt.virksomhetsnummer)) {
+        if (ansatt == null) {
             throw new ForbiddenException();
         }
 
@@ -145,8 +145,8 @@ public class OppfolgingsplanService {
 
     private List<Oppfolgingsplan> arbeidstakersOppfolgingsplaner(String aktorId) {
         return oppfolgingsplanDAO.oppfolgingsplanerKnyttetTilSykmeldt(aktorId).stream()
-                .peek(oppfoelgingsdialog -> oppfolgingsplanDAO.oppdaterSistAksessert(oppfoelgingsdialog, aktorId))
-                .map(oppfoelgingsdialog -> oppfolgingsplanDAO.populate(oppfoelgingsdialog))
+                .peek(oppfolgingsplan -> oppfolgingsplanDAO.oppdaterSistAksessert(oppfolgingsplan, aktorId))
+                .map(oppfolgingsplan -> oppfolgingsplanDAO.populate(oppfolgingsplan))
                 .collect(toList());
     }
 

--- a/src/main/java/no/nav/syfo/service/TilgangskontrollService.java
+++ b/src/main/java/no/nav/syfo/service/TilgangskontrollService.java
@@ -34,7 +34,7 @@ public class TilgangskontrollService {
                 || erNaermesteLederForSykmeldt(innloggetFnr, sykmeldtFnr, virksomhetsnummer);
     }
 
-    public boolean erNaermesteLederForSykmeldt(String lederFnr, String sykmeldtFnr, String virksomhetsnummer) {
+    private boolean erNaermesteLederForSykmeldt(String lederFnr, String sykmeldtFnr, String virksomhetsnummer) {
         return narmesteLederConsumer.ansatte(lederFnr).stream()
                 .anyMatch(ansatt -> virksomhetsnummer.equals(ansatt.virksomhetsnummer) && ansatt.fnr.equals(sykmeldtFnr));
     }

--- a/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2.kt
+++ b/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2.kt
@@ -56,7 +56,7 @@ class ArbeidsgiverOppfolgingsplanControllerV2 @Inject constructor(
             .fnrFromIdportenTokenX()
             .value
         val arbeidsgiversOppfolgingsplaner = oppfolgingsplanService.arbeidsgiveroppfolgingsplanerPaFnr(innloggetIdent, fnr)
-        val liste = arbeidsgiversOppfolgingsplaner.map { it.toBrukerOppfolgingsplan() }
+        val liste = arbeidsgiversOppfolgingsplaner.map { it.toBrukerOppfolgingsplan(pdlConsumer) }
         liste.forEach { plan -> plan.populerPlanerMedAvbruttPlanListe(liste) }
         liste.forEach { plan -> plan.populerArbeidstakersStillinger(aaregConsumer) }
         metrikk.tellHendelse("hent_oppfolgingsplan_ag")

--- a/src/main/kotlin/no/nav/syfo/lps/OppfolgingsplanLPSService.kt
+++ b/src/main/kotlin/no/nav/syfo/lps/OppfolgingsplanLPSService.kt
@@ -132,7 +132,7 @@ class OppfolgingsplanLPSService @Inject constructor(
 
         val isUserDiskresjonsmerket = try {
             pdlConsumer.person(incomingMetadata.userPersonNumber)?.isKode6Or7()
-        }  catch (e: HttpServerErrorException) {
+        } catch (e: HttpServerErrorException) {
             log.error("Could not process LPS-plan due to server error: ${e.message}")
             null
         }


### PR DESCRIPTION
New endpoint to query on a single SM-AG relation / OP set, to alleviate recent performance issues and timeouts seen in client-to-backend traffic.