### PR TITLE
Fix cache for Felles kodeverk

### DIFF
--- a/src/main/java/no/nav/syfo/fellesKodeverk/Beskrivelse.java
+++ b/src/main/java/no/nav/syfo/fellesKodeverk/Beskrivelse.java
@@ -3,9 +3,11 @@ package no.nav.syfo.fellesKodeverk;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
+import java.io.Serializable;
+
 @Data
 @Accessors(fluent = true)
-public class Beskrivelse {
+public class Beskrivelse implements Serializable {
     public String tekst;
     public String term;
 }

--- a/src/main/java/no/nav/syfo/fellesKodeverk/Betydning.java
+++ b/src/main/java/no/nav/syfo/fellesKodeverk/Betydning.java
@@ -3,11 +3,12 @@ package no.nav.syfo.fellesKodeverk;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
+import java.io.Serializable;
 import java.util.Map;
 
 @Data
 @Accessors(fluent = true)
-public class Betydning {
+public class Betydning implements Serializable {
     public Map<String, Beskrivelse> beskrivelser;
     public String gyldigFra;
     public String gyldigTil;

--- a/src/main/java/no/nav/syfo/fellesKodeverk/KodeverkKoderBetydningerResponse.java
+++ b/src/main/java/no/nav/syfo/fellesKodeverk/KodeverkKoderBetydningerResponse.java
@@ -3,11 +3,12 @@ package no.nav.syfo.fellesKodeverk;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
 @Data
 @Accessors(fluent = true)
-public class KodeverkKoderBetydningerResponse {
+public class KodeverkKoderBetydningerResponse implements Serializable {
     public Map<String, List<Betydning>> betydninger;
 }

--- a/src/test/java/no/nav/syfo/aareg/utils/AaregConsumerTestUtils.java
+++ b/src/test/java/no/nav/syfo/aareg/utils/AaregConsumerTestUtils.java
@@ -15,6 +15,7 @@ public class AaregConsumerTestUtils {
     public static final LocalDate PASSED_DATE = LocalDate.of(1970, 1, 2);
     public static final String YRKESKODE = "1234567";
     public static final String YRKESNAVN = "yrkesnavn";
+    public static final String YRKESNAVN_CAPITALIZED = "Yrkesnavn";
     public static final Double STILLINGSPROSENT = 50.0;
 
     public static Arbeidsforhold simpleArbeidsforhold() {

--- a/src/test/kotlin/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumerTest.kt
@@ -24,26 +24,8 @@ class FellesKodeverkConsumerTest : TestCase() {
     private lateinit var fellesKodeverkConsumer: FellesKodeverkConsumer
 
     @Test
-    fun stillingsnavnFromKode_gives_correct_stillingsnavn() {
-        val expectedResponse = responseBody()
-        Mockito.`when`(restTemplate.exchange(ArgumentMatchers.anyString(), ArgumentMatchers.eq(HttpMethod.GET), ArgumentMatchers.any(HttpEntity::class.java), ArgumentMatchers.eq(KodeverkKoderBetydningerResponse::class.java))).thenReturn(ResponseEntity(expectedResponse, HttpStatus.OK))
-        val actualStillingsnavn = fellesKodeverkConsumer.stillingsnavnFromKode(STILLINGSKODE)
-        Assertions.assertThat(actualStillingsnavn).isEqualTo(STILLINGSNAVN_LOWERCAPITALIZED)
-        Mockito.verify(metric).tellHendelse("call_felleskodeverk_success")
-    }
-
-    @Test
-    fun stillingsnavnFromKode_return_custom_message_if_navn_not_found() {
-        val expectedResponse = responseBodyWithWrongKode()
-        Mockito.`when`(restTemplate.exchange(ArgumentMatchers.anyString(), ArgumentMatchers.eq(HttpMethod.GET), ArgumentMatchers.any(HttpEntity::class.java), ArgumentMatchers.eq(KodeverkKoderBetydningerResponse::class.java))).thenReturn(ResponseEntity(expectedResponse, HttpStatus.OK))
-        val actualStillingsnavn = fellesKodeverkConsumer.stillingsnavnFromKode(STILLINGSKODE)
-        Assertions.assertThat(actualStillingsnavn).isEqualTo("Ugyldig yrkeskode $STILLINGSKODE")
-        Mockito.verify(metric).tellHendelse("call_felleskodeverk_success")
-    }
-
-    @Test
     fun get_kodeverkKoderBetydninger() {
-        val expectedResponse = responseBody()
+        val expectedResponse = fellesKodeverkResponseBody(STILLINGSNAVN, STILLINGSKODE)
         Mockito.`when`(restTemplate.exchange(ArgumentMatchers.anyString(), ArgumentMatchers.eq(HttpMethod.GET), ArgumentMatchers.any(HttpEntity::class.java), ArgumentMatchers.eq(KodeverkKoderBetydningerResponse::class.java))).thenReturn(ResponseEntity(expectedResponse, HttpStatus.OK))
         val actualResponse = fellesKodeverkConsumer.kodeverkKoderBetydninger()
         Assertions.assertThat(actualResponse.betydninger[STILLINGSKODE]).isNotNull
@@ -62,46 +44,5 @@ class FellesKodeverkConsumerTest : TestCase() {
             Assertions.assertThat(e.javaClass).isEqualTo(RuntimeException::class.java)
             Assertions.assertThat(e.message).isEqualTo("Tried to get kodeBetydninger from Felles Kodeverk")
         }
-    }
-
-    private fun responseBody(): KodeverkKoderBetydningerResponse {
-        val beskrivelse = Beskrivelse()
-            .tekst(STILLINGSNAVN)
-            .term(STILLINGSNAVN)
-        val beskrivelser: MutableMap<String, Beskrivelse> = HashMap()
-        beskrivelser[SPRAK] = beskrivelse
-        val betydning = Betydning()
-            .beskrivelser(beskrivelser)
-            .gyldigFra(Date().toString())
-            .gyldigTil(Date().toString())
-        val betydninger: MutableMap<String, List<Betydning>> = HashMap()
-        betydninger[STILLINGSKODE] = listOf(betydning)
-        return KodeverkKoderBetydningerResponse()
-            .betydninger(betydninger)
-    }
-
-    private fun responseBodyWithWrongKode(): KodeverkKoderBetydningerResponse {
-        val beskrivelse = Beskrivelse()
-            .tekst(WRONG_STILLINGSNAVN)
-            .term(WRONG_STILLINGSNAVN)
-        val beskrivelser: MutableMap<String, Beskrivelse> = HashMap()
-        beskrivelser[SPRAK] = beskrivelse
-        val betydning = Betydning()
-            .beskrivelser(beskrivelser)
-            .gyldigFra(Date().toString())
-            .gyldigTil(Date().toString())
-        val betydninger: MutableMap<String, List<Betydning>> = HashMap()
-        betydninger[WRONG_STILLINGSKODE] = listOf(betydning)
-        return KodeverkKoderBetydningerResponse()
-            .betydninger(betydninger)
-    }
-
-    companion object {
-        private const val STILLINGSNAVN = "Special Agent"
-        private const val STILLINGSNAVN_LOWERCAPITALIZED = "Special agent"
-        private const val WRONG_STILLINGSNAVN = "Deputy Director"
-        private const val STILLINGSKODE = "1234567"
-        private const val WRONG_STILLINGSKODE = "9876543"
-        private const val SPRAK = "nb"
     }
 }

--- a/src/test/kotlin/no/nav/syfo/fellesKodeverk/FellesKodeverkTestUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/fellesKodeverk/FellesKodeverkTestUtils.kt
@@ -1,0 +1,42 @@
+package no.nav.syfo.fellesKodeverk
+
+import java.util.*
+
+fun fellesKodeverkResponseBody(stillingsnavn: String, stillingskode: String): KodeverkKoderBetydningerResponse {
+    val beskrivelse = Beskrivelse()
+        .tekst(stillingsnavn)
+        .term(stillingsnavn)
+    val beskrivelser: MutableMap<String, Beskrivelse> = HashMap()
+    beskrivelser[SPRAK] = beskrivelse
+    val betydning = Betydning()
+        .beskrivelser(beskrivelser)
+        .gyldigFra(Date().toString())
+        .gyldigTil(Date().toString())
+    val betydninger: MutableMap<String, List<Betydning>> = HashMap()
+    betydninger[stillingskode] = listOf(betydning)
+    return KodeverkKoderBetydningerResponse()
+        .betydninger(betydninger)
+}
+
+fun fellesKodeverkResponseBodyWithWrongKode(): KodeverkKoderBetydningerResponse {
+    val beskrivelse = Beskrivelse()
+        .tekst(WRONG_STILLINGSNAVN)
+        .term(WRONG_STILLINGSNAVN)
+    val beskrivelser: MutableMap<String, Beskrivelse> = HashMap()
+    beskrivelser[SPRAK] = beskrivelse
+    val betydning = Betydning()
+        .beskrivelser(beskrivelser)
+        .gyldigFra(Date().toString())
+        .gyldigTil(Date().toString())
+    val betydninger: MutableMap<String, List<Betydning>> = HashMap()
+    betydninger[WRONG_STILLINGSKODE] = listOf(betydning)
+    return KodeverkKoderBetydningerResponse()
+        .betydninger(betydninger)
+}
+
+
+const val STILLINGSNAVN = "Special Agent"
+const val WRONG_STILLINGSNAVN = "Deputy Director"
+const val STILLINGSKODE = "1234567"
+const val WRONG_STILLINGSKODE = "9876543"
+const val SPRAK = "nb"


### PR DESCRIPTION
@Cacheable-annotasjonen fungerer ikke når man kaller metoden fra en annen metode i samme bønne. Jeg har introdusert en ArbeidsforholdService som kaller FellesKodeverkConsumer i stedet. Da fungerer cachen som den skal. 