### PR TITLE
Move BrukerkontekstConstant to service package

### DIFF
--- a/src/main/java/no/nav/syfo/service/BrukerkontekstConstant.java
+++ b/src/main/java/no/nav/syfo/service/BrukerkontekstConstant.java
@@ -1,4 +1,4 @@
-package no.nav.syfo.api.selvbetjening.domain;
+package no.nav.syfo.service;
 
 public enum BrukerkontekstConstant {
     ARBEIDSTAKER,

--- a/src/main/java/no/nav/syfo/service/OppfolgingsplanService.java
+++ b/src/main/java/no/nav/syfo/service/OppfolgingsplanService.java
@@ -1,6 +1,5 @@
 package no.nav.syfo.service;
 
-import no.nav.syfo.api.selvbetjening.domain.BrukerkontekstConstant;
 import no.nav.syfo.api.selvbetjening.domain.RSOpprettOppfoelgingsdialog;
 import no.nav.syfo.dialogmelding.DialogmeldingService;
 import no.nav.syfo.domain.*;
@@ -24,8 +23,8 @@ import java.util.Optional;
 import static java.time.LocalDateTime.now;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
-import static no.nav.syfo.api.selvbetjening.domain.BrukerkontekstConstant.ARBEIDSGIVER;
-import static no.nav.syfo.api.selvbetjening.domain.BrukerkontekstConstant.ARBEIDSTAKER;
+import static no.nav.syfo.service.BrukerkontekstConstant.ARBEIDSGIVER;
+import static no.nav.syfo.service.BrukerkontekstConstant.ARBEIDSTAKER;
 import static org.slf4j.LoggerFactory.getLogger;
 
 @Service

--- a/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2.kt
+++ b/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2.kt
@@ -2,7 +2,7 @@ package no.nav.syfo.api.v2.controller
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
-import no.nav.syfo.api.selvbetjening.domain.BrukerkontekstConstant.ARBEIDSGIVER
+import no.nav.syfo.service.BrukerkontekstConstant.ARBEIDSGIVER
 import no.nav.syfo.api.selvbetjening.domain.RSOpprettOppfoelgingsdialog
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.BrukerOppfolgingsplan
 import no.nav.syfo.api.v2.mapper.populerArbeidstakersStillinger

--- a/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2.kt
+++ b/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2.kt
@@ -2,7 +2,7 @@ package no.nav.syfo.api.v2.controller
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
-import no.nav.syfo.api.selvbetjening.domain.BrukerkontekstConstant
+import no.nav.syfo.service.BrukerkontekstConstant
 import no.nav.syfo.api.selvbetjening.domain.RSOpprettOppfoelgingsdialog
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.BrukerOppfolgingsplan
 import no.nav.syfo.api.v2.mapper.populerArbeidstakersStillinger

--- a/src/main/kotlin/no/nav/syfo/api/v2/controller/OppfolgingsplanControllerV2.kt
+++ b/src/main/kotlin/no/nav/syfo/api/v2/controller/OppfolgingsplanControllerV2.kt
@@ -4,7 +4,7 @@ import java.util.*
 import javax.inject.Inject
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
-import no.nav.syfo.api.selvbetjening.domain.BrukerkontekstConstant.*
+import no.nav.syfo.service.BrukerkontekstConstant.*
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.ArbeidsoppgaveRequest
 import no.nav.syfo.api.v2.mapper.toArbeidsoppgave
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.TiltakRequest

--- a/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2Test.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.api.v2.controller
 
 import no.nav.syfo.api.AbstractRessursTilgangTest
-import no.nav.syfo.api.selvbetjening.domain.BrukerkontekstConstant
+import no.nav.syfo.service.BrukerkontekstConstant
 import no.nav.syfo.api.selvbetjening.domain.RSOpprettOppfoelgingsdialog
 import no.nav.syfo.metric.Metrikk
 import no.nav.syfo.narmesteleder.NarmesteLederConsumer

--- a/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2Test.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.api.v2.controller
 
 import no.nav.syfo.api.AbstractRessursTilgangTest
-import no.nav.syfo.api.selvbetjening.domain.BrukerkontekstConstant
+import no.nav.syfo.service.BrukerkontekstConstant
 import no.nav.syfo.api.selvbetjening.domain.RSOpprettOppfoelgingsdialog
 import no.nav.syfo.metric.Metrikk
 import no.nav.syfo.service.OppfolgingsplanService

--- a/src/test/kotlin/no/nav/syfo/api/v2/controller/OppfolgingsplanControllerV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/api/v2/controller/OppfolgingsplanControllerV2Test.kt
@@ -2,13 +2,13 @@ package no.nav.syfo.api.v2.controller
 
 import javax.inject.Inject
 import no.nav.syfo.api.AbstractRessursTilgangTest
-import no.nav.syfo.api.selvbetjening.domain.BrukerkontekstConstant.*
+import no.nav.syfo.service.BrukerkontekstConstant.*
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.ArbeidsoppgaveRequest
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.Gjennomfoering
 import no.nav.syfo.api.v2.mapper.toArbeidsoppgave
+import no.nav.syfo.api.v2.controller.OppfolgingsplanControllerV2.Companion.METRIC_SHARE_WITH_NAV_AT_APPROVAL
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.TiltakRequest
 import no.nav.syfo.api.v2.mapper.toTiltak
-import no.nav.syfo.api.v2.controller.OppfolgingsplanControllerV2.Companion.METRIC_SHARE_WITH_NAV_AT_APPROVAL
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.Gyldighetstidspunkt
 import no.nav.syfo.domain.Arbeidsoppgave
 import no.nav.syfo.domain.Gjennomfoering.*

--- a/src/test/kotlin/no/nav/syfo/oppgave/OppfolgingsplanServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppgave/OppfolgingsplanServiceTest.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.oppgave
 
-import no.nav.syfo.api.selvbetjening.domain.BrukerkontekstConstant
+import no.nav.syfo.service.BrukerkontekstConstant
 import no.nav.syfo.domain.*
 import no.nav.syfo.model.Ansatt
 import no.nav.syfo.narmesteleder.NarmesteLederConsumer


### PR DESCRIPTION
Etter at de andre typene var konvertert til kotlin er denne den eneste som ligger igjen i pakken. Det er mer naturlig at den ligger samme sted som servicen som bruker den.