### PR TITLE
Remove unused arbeidsgiver endpoint

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2.kt
+++ b/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2.kt
@@ -2,7 +2,6 @@ package no.nav.syfo.api.v2.controller
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
-import no.nav.syfo.service.BrukerkontekstConstant.ARBEIDSGIVER
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.BrukerOppfolgingsplan
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.OpprettOppfolgingsplanRequest
 import no.nav.syfo.api.v2.mapper.populerArbeidstakersStillinger
@@ -37,18 +36,6 @@ class ArbeidsgiverOppfolgingsplanControllerV2 @Inject constructor(
     @Value("\${oppfolgingsplan.frontend.client.id}")
     private val oppfolgingsplanClientId: String
 ) {
-    @GetMapping(produces = [APPLICATION_JSON_VALUE])
-    fun hentArbeidsgiversOppfolgingsplaner(): List<BrukerOppfolgingsplan> {
-        val innloggetIdent = TokenXUtil.validateTokenXClaims(contextHolder, tokenxIdp, oppfolgingsplanClientId)
-            .fnrFromIdportenTokenX()
-            .value
-        val arbeidsgiversOppfolgingsplaner = oppfolgingsplanService.hentAktorsOppfolgingsplaner(ARBEIDSGIVER, innloggetIdent)
-        val liste = arbeidsgiversOppfolgingsplaner.map { it.toBrukerOppfolgingsplan(pdlConsumer) }
-        liste.forEach { plan -> plan.populerPlanerMedAvbruttPlanListe(liste) }
-        liste.forEach { plan -> plan.populerArbeidstakersStillinger(arbeidsforholdService) }
-        metrikk.tellHendelse("hent_oppfolgingsplan_ag")
-        return liste
-    }
 
     @GetMapping(produces = [APPLICATION_JSON_VALUE], value = ["/{fnr}"])
     fun hentArbeidsgiversOppfolgingsplanerPaFnr(@PathVariable fnr: String, @RequestParam("virksomhetsnummer") virksomhetsnummer: String): List<BrukerOppfolgingsplan> {

--- a/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2.kt
+++ b/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2.kt
@@ -2,7 +2,6 @@ package no.nav.syfo.api.v2.controller
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
-import no.nav.syfo.service.BrukerkontekstConstant
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.OpprettOppfolgingsplanRequest
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.BrukerOppfolgingsplan
 import no.nav.syfo.api.v2.mapper.populerArbeidstakersStillinger
@@ -44,7 +43,7 @@ class ArbeidstakerOppfolgingsplanControllerV2 @Inject constructor(
                 .fnrFromIdportenTokenX()
                 .value
         val arbeidstakersOppfolgingsplaner: List<Oppfolgingsplan> =
-            oppfolgingsplanService.hentAktorsOppfolgingsplaner(BrukerkontekstConstant.ARBEIDSTAKER, innloggetIdent)
+            oppfolgingsplanService.arbeidstakersOppfolgingsplaner(innloggetIdent)
         val liste = arbeidstakersOppfolgingsplaner.map { it.toBrukerOppfolgingsplan(pdlConsumer) }
         liste.forEach { plan -> plan.populerPlanerMedAvbruttPlanListe(liste) }
         liste.forEach { plan -> plan.populerArbeidstakersStillinger(arbeidsforholdService) }

--- a/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2Test.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.api.v2.controller
 
 import no.nav.syfo.api.AbstractRessursTilgangTest
-import no.nav.syfo.service.BrukerkontekstConstant
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.OpprettOppfolgingsplanRequest
 import no.nav.syfo.metric.Metrikk
 import no.nav.syfo.narmesteleder.NarmesteLederConsumer
@@ -45,17 +44,10 @@ class ArbeidsgiverOppfolgingsplanControllerV2Test : AbstractRessursTilgangTest()
         loggInnBrukerTokenX(contextHolder, LEDER_FNR, oppfolgingsplanClientId, tokenxIdp)
     }
 
-    @Test
-    fun hent_oppfolgingsplaner_som_arbeidsgiver() {
-        arbeidsgiverOppfolgingsplanController.hentArbeidsgiversOppfolgingsplaner()
-        Mockito.verify(oppfolgingsplanService).hentAktorsOppfolgingsplaner(BrukerkontekstConstant.ARBEIDSGIVER, LEDER_FNR)
-        Mockito.verify(metrikk).tellHendelse("hent_oppfolgingsplan_ag")
-    }
-
     @Test(expected = RuntimeException::class)
     fun hent_oppfolgingsplaner_finner_ikke_innlogget_bruker() {
         loggUtAlle(contextHolder)
-        arbeidsgiverOppfolgingsplanController.hentArbeidsgiversOppfolgingsplaner()
+        arbeidsgiverOppfolgingsplanController.hentArbeidsgiversOppfolgingsplanerPaFnr(ARBEIDSTAKER_FNR, VIRKSOMHETSNUMMER)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2Test.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.api.v2.controller
 
 import no.nav.syfo.api.AbstractRessursTilgangTest
-import no.nav.syfo.service.BrukerkontekstConstant
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.OpprettOppfolgingsplanRequest
 import no.nav.syfo.metric.Metrikk
 import no.nav.syfo.service.OppfolgingsplanService
@@ -43,7 +42,7 @@ class ArbeidstakerOppfolgingsplanControllerV2Test : AbstractRessursTilgangTest()
     @Test
     fun henter_oppfolgingsplaner_som_arbeidstaker() {
         arbeidstakerOppfolgingsplanController.hentArbeidstakersOppfolgingsplaner()
-        verify(oppfolgingsplanService).hentAktorsOppfolgingsplaner(BrukerkontekstConstant.ARBEIDSTAKER, ARBEIDSTAKER_FNR)
+        verify(oppfolgingsplanService).arbeidstakersOppfolgingsplaner(ARBEIDSTAKER_FNR)
         verify(metrikk).tellHendelse("hent_oppfolgingsplan_at")
     }
 

--- a/src/test/kotlin/no/nav/syfo/oppgave/OppfolgingsplanServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppgave/OppfolgingsplanServiceTest.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.oppgave
 
 import no.nav.syfo.domain.*
-import no.nav.syfo.narmesteleder.NarmesteLederConsumer
 import no.nav.syfo.pdl.PdlConsumer
 import no.nav.syfo.repository.dao.GodkjentplanDAO
 import no.nav.syfo.repository.dao.OppfolgingsplanDAO
@@ -22,9 +21,6 @@ import javax.ws.rs.ForbiddenException
 class OppfolgingsplanServiceTest {
     @Mock
     private lateinit var oppfolgingsplanDAO: OppfolgingsplanDAO
-
-    @Mock
-    private lateinit var narmesteLederConsumer: NarmesteLederConsumer
 
     @Mock
     private lateinit var tilgangskontrollService: TilgangskontrollService


### PR DESCRIPTION
Det har blitt laget et nytt endepunkt som lar arbeidsgiver hente oppfølgingsplaner til den sykmeldte hen er inne på. Da trenger vi ikke lenger dette endepunktet som henter alle oppfølgingsplaner til alle sykmeldte en person er leder for. Dette gjør at jeg kan rydde opp litt mer i min andre pr #343 