### PR TITLE
Refactored fetching of stillinger to improve response time

### DIFF
--- a/src/main/java/no/nav/syfo/model/Stilling.java
+++ b/src/main/java/no/nav/syfo/model/Stilling.java
@@ -4,10 +4,14 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 @Data
 @Accessors(fluent = true)
 public class Stilling {
     public String yrke;
     public BigDecimal prosent;
+    public LocalDate fom;
+    public LocalDate tom;
+    public String orgnummer;
 }

--- a/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2.kt
+++ b/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2.kt
@@ -45,7 +45,8 @@ class ArbeidsgiverOppfolgingsplanControllerV2 @Inject constructor(
         val arbeidsgiversOppfolgingsplaner = oppfolgingsplanService.arbeidsgiversOppfolgingsplanerPaFnr(innloggetIdent, fnr, virksomhetsnummer)
         val liste = arbeidsgiversOppfolgingsplaner.map { it.toBrukerOppfolgingsplan(pdlConsumer) }
         liste.forEach { plan -> plan.populerPlanerMedAvbruttPlanListe(liste) }
-        liste.forEach { plan -> plan.populerArbeidstakersStillinger(arbeidsforholdService) }
+        val arbeidsforhold = arbeidsforholdService.arbeidstakersStillingerForOrgnummer(fnr, virksomhetsnummer)
+        liste.forEach { plan -> plan.populerArbeidstakersStillinger(arbeidsforhold) }
         metrikk.tellHendelse("hent_oppfolgingsplan_ag")
         return liste
     }

--- a/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2.kt
+++ b/src/main/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2.kt
@@ -46,7 +46,8 @@ class ArbeidstakerOppfolgingsplanControllerV2 @Inject constructor(
             oppfolgingsplanService.arbeidstakersOppfolgingsplaner(innloggetIdent)
         val liste = arbeidstakersOppfolgingsplaner.map { it.toBrukerOppfolgingsplan(pdlConsumer) }
         liste.forEach { plan -> plan.populerPlanerMedAvbruttPlanListe(liste) }
-        liste.forEach { plan -> plan.populerArbeidstakersStillinger(arbeidsforholdService) }
+        val arbeidstakersStillinger = arbeidsforholdService.arbeidstakersStillinger(innloggetIdent)
+        liste.forEach { plan -> plan.populerArbeidstakersStillinger(arbeidstakersStillinger) }
         metrikk.tellHendelse("hent_oppfolgingsplan_at")
         return liste
     }

--- a/src/main/kotlin/no/nav/syfo/api/v2/mapper/BrukerOppfolgingsplanMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/api/v2/mapper/BrukerOppfolgingsplanMapper.kt
@@ -1,6 +1,5 @@
 package no.nav.syfo.api.v2.mapper
 
-import no.nav.syfo.aareg.exceptions.RestErrorFromAareg
 import no.nav.syfo.api.util.unwrap
 import no.nav.syfo.api.v2.domain.Virksomhet
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.*
@@ -16,7 +15,6 @@ import no.nav.syfo.domain.Gyldighetstidspunkt
 import no.nav.syfo.domain.Kommentar
 import no.nav.syfo.domain.Tiltak
 import no.nav.syfo.pdl.PdlConsumer
-import no.nav.syfo.service.ArbeidsforholdService
 import java.time.LocalDate
 
 fun Oppfolgingsplan.toBrukerOppfolgingsplan(pdlConsumer: PdlConsumer) =
@@ -175,11 +173,9 @@ fun BrukerOppfolgingsplan.populerPlanerMedAvbruttPlanListe(planer: List<BrukerOp
         }
 }
 
-fun BrukerOppfolgingsplan.populerArbeidstakersStillinger(arbeidsforholdService: ArbeidsforholdService) {
-    try {
-        arbeidstaker.stillinger =
-            arbeidsforholdService.arbeidstakersFnrStillingerForOrgnummer(arbeidstaker.fnr, opprettetDato, virksomhet.virksomhetsnummer)
-                .map { stilling -> Stilling(stilling.yrke, stilling.prosent) }
-    } catch (_: RestErrorFromAareg) {
-    }
+fun BrukerOppfolgingsplan.populerArbeidstakersStillinger(arbeidsforhold: List<no.nav.syfo.model.Stilling>) {
+    arbeidstaker.stillinger = arbeidsforhold
+        .filter { stilling -> stilling.fom.isBefore(opprettetDato) && (stilling.tom == null || stilling.tom.isAfter(opprettetDato)) }
+        .filter { stilling -> stilling.orgnummer.equals(virksomhet.virksomhetsnummer) }
+        .map { stilling -> Stilling(stilling.yrke, stilling.prosent) }
 }

--- a/src/main/kotlin/no/nav/syfo/api/v3/controller/ArbeidsforholdControllerV3.kt
+++ b/src/main/kotlin/no/nav/syfo/api/v3/controller/ArbeidsforholdControllerV3.kt
@@ -12,7 +12,6 @@ import no.nav.syfo.tokenx.TokenXUtil.fnrFromIdportenTokenX
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDate
 import javax.inject.Inject
 
 
@@ -40,7 +38,6 @@ class ArbeidsforholdControllerV3 @Inject constructor(
     fun getArbeidsforhold(
         @RequestParam("fnr") fnr: String,
         @RequestParam("virksomhetsnummer") virksomhetsnummer: String,
-        @RequestParam("fom") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) fom: LocalDate
     ): ResponseEntity<List<Arbeidsforhold>> {
 
         val innloggetIdent = TokenXUtil.validateTokenXClaims(contextHolder, tokenxIdp, oppfolgingsplanClientId)
@@ -53,7 +50,7 @@ class ArbeidsforholdControllerV3 @Inject constructor(
                 .status(HttpStatus.FORBIDDEN)
                 .build()
         }
-        val arbeidsforhold = arbeidsforholdService.arbeidstakersFnrStillingerForOrgnummer(fnr, fom, virksomhetsnummer)
+        val arbeidsforhold = arbeidsforholdService.arbeidstakersStillingerForOrgnummer(fnr, virksomhetsnummer)
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(arbeidsforhold.map { it.mapToArbeidsforhold() })

--- a/src/main/kotlin/no/nav/syfo/api/v3/domain/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/syfo/api/v3/domain/Arbeidsforhold.kt
@@ -2,15 +2,20 @@ package no.nav.syfo.api.v3.domain
 
 import no.nav.syfo.model.Stilling
 import java.math.BigDecimal
+import java.time.LocalDate
 
-data class Arbeidsforhold (
+data class  Arbeidsforhold (
     val yrke: String,
-    val prosent: BigDecimal
+    val prosent: BigDecimal,
+    val fom: LocalDate,
+    val tom: LocalDate
 )
 
 fun Stilling.mapToArbeidsforhold(): Arbeidsforhold {
     return Arbeidsforhold(
         yrke = this.yrke,
-        prosent = this.prosent
+        prosent = this.prosent,
+        fom = this.fom,
+        tom = this.tom,
     )
 }

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsforholdService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsforholdService.kt
@@ -50,8 +50,8 @@ class ArbeidsforholdService(private val aaregConsumer: AaregConsumer, private va
     }
 
     fun beregnRiktigFom(gyldighetsperiodeFom: String?, ansettelsesperiodeFom: String): LocalDate {
-        // Gyldighetsperiode sier noe om hvilken måned arbeidsavtalen er rapportert inn, og starter på den 1. i måneden selv om arbeidsforholdet startet senere.
-        // Så dersom gyldighetsperiode er før ansettelsesperioden er det riktig å bruke ansettelsesperioden sin fom.
+        /* Gyldighetsperiode sier noe om hvilken måned arbeidsavtalen er rapportert inn, og starter på den 1. i måneden selv om arbeidsforholdet startet senere.
+         Så dersom gyldighetsperiode er før ansettelsesperioden er det riktig å bruke ansettelsesperioden sin fom.*/
         val ansattFom = ansettelsesperiodeFom.tilLocalDate()
         return if (gyldighetsperiodeFom == null || LocalDate.parse(gyldighetsperiodeFom).isBefore(ansattFom)) {
             ansattFom

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsforholdService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsforholdService.kt
@@ -61,8 +61,8 @@ class ArbeidsforholdService(private val aaregConsumer: AaregConsumer, private va
     }
 
     fun beregnRiktigTom(gyldighetsperiodeTom: String?, ansettelsesperiodeTom: String?): LocalDate? {
-        // Den siste arbeidsavtalen har alltid tom = null, selv om arbeidsforholdet er avsluttet. Så dersom tom = null og ansettelsesperiodens tom ikke er null,
-        // er det riktig å bruke ansettelsesperioden sin tom
+        /* Den siste arbeidsavtalen har alltid tom = null, selv om arbeidsforholdet er avsluttet. Så dersom tom = null og ansettelsesperiodens tom ikke er null,
+         er det riktig å bruke ansettelsesperioden sin tom */
         return if (gyldighetsperiodeTom != null) {
             gyldighetsperiodeTom.tilLocalDate()
         } else if (ansettelsesperiodeTom != null) {

--- a/src/main/kotlin/no/nav/syfo/service/ArbeidsforholdService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ArbeidsforholdService.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.service
 
 import no.nav.syfo.aareg.AaregConsumer
 import no.nav.syfo.aareg.AaregUtils.stillingsprosentWithMaxScale
+import no.nav.syfo.aareg.Arbeidsavtale
 import no.nav.syfo.aareg.Arbeidsforhold
 import no.nav.syfo.aareg.OpplysningspliktigArbeidsgiver
 import no.nav.syfo.fellesKodeverk.FellesKodeverkConsumer
@@ -24,11 +25,55 @@ class ArbeidsforholdService(private val aaregConsumer: AaregConsumer, private va
         return arbeidsforholdList2StillingForOrgnummer(arbeidsforholdList, orgnummer, fom)
     }
 
-    fun arbeidstakersFnrStillingerForOrgnummer(fnr: String, fom: LocalDate, orgnummer: String): List<Stilling> {
-        return arbeidsforholdList2StillingForOrgnummer(aaregConsumer.arbeidsforholdArbeidstaker(fnr), orgnummer, fom)
+    fun arbeidstakersStillingerForOrgnummer(fnr: String, orgnummer: String): List<Stilling> {
+        return arbeidstakersStillinger(fnr)
+            .filter { stilling -> stilling.orgnummer.equals(orgnummer) }
+    }
+
+    fun arbeidstakersStillinger(fnr: String): List<Stilling> {
+        val kodeverkBetydninger = fellesKodeverkConsumer.kodeverkKoderBetydninger()
+        return aaregConsumer.arbeidsforholdArbeidstaker(fnr)
+            .filter { arbeidsforhold -> arbeidsforhold.arbeidsgiver.type.equals(OpplysningspliktigArbeidsgiver.Type.Organisasjon) }
+            .flatMap { arbeidsforhold ->
+                arbeidsforhold.arbeidsavtaler
+                    .sortedWith(compareBy<Arbeidsavtale, String?>(nullsLast()) { it.gyldighetsperiode.fom })
+                    .map {
+                        Stilling().apply {
+                            yrke = stillingsnavnFromKode(it.yrke, kodeverkBetydninger)
+                            prosent = stillingsprosentWithMaxScale(it.stillingsprosent)
+                            fom = beregnRiktigFom(it.gyldighetsperiode.fom, arbeidsforhold.ansettelsesperiode.periode.fom)
+                            tom = beregnRiktigTom(it.gyldighetsperiode.tom, arbeidsforhold.ansettelsesperiode.periode.tom)
+                            orgnummer = arbeidsforhold.arbeidsgiver.organisasjonsnummer
+                        }
+                    }
+            }
+    }
+
+    fun beregnRiktigFom(gyldighetsperiodeFom: String?, ansettelsesperiodeFom: String): LocalDate {
+        // Gyldighetsperiode sier noe om hvilken måned arbeidsavtalen er rapportert inn, og starter på den 1. i måneden selv om arbeidsforholdet startet senere.
+        // Så dersom gyldighetsperiode er før ansettelsesperioden er det riktig å bruke ansettelsesperioden sin fom.
+        val ansattFom = ansettelsesperiodeFom.tilLocalDate()
+        return if (gyldighetsperiodeFom == null || LocalDate.parse(gyldighetsperiodeFom).isBefore(ansattFom)) {
+            ansattFom
+        } else {
+            gyldighetsperiodeFom.tilLocalDate()
+        }
+    }
+
+    fun beregnRiktigTom(gyldighetsperiodeTom: String?, ansettelsesperiodeTom: String?): LocalDate? {
+        // Den siste arbeidsavtalen har alltid tom = null, selv om arbeidsforholdet er avsluttet. Så dersom tom = null og ansettelsesperiodens tom ikke er null,
+        // er det riktig å bruke ansettelsesperioden sin tom
+        return if (gyldighetsperiodeTom != null) {
+            gyldighetsperiodeTom.tilLocalDate()
+        } else if (ansettelsesperiodeTom != null) {
+            ansettelsesperiodeTom.tilLocalDate()
+        } else {
+            null
+        }
     }
 
     private fun arbeidsforholdList2StillingForOrgnummer(arbeidsforholdListe: List<Arbeidsforhold>, orgnummer: String, fom: LocalDate): List<Stilling> {
+        val kodeverkBetydninger = fellesKodeverkConsumer.kodeverkKoderBetydninger()
         return arbeidsforholdListe
             .filter { arbeidsforhold -> arbeidsforhold.arbeidsgiver.type.equals(OpplysningspliktigArbeidsgiver.Type.Organisasjon) }
             .filter { arbeidsforhold -> arbeidsforhold.arbeidsgiver.organisasjonsnummer.equals(orgnummer) }
@@ -40,14 +85,13 @@ class ArbeidsforholdService(private val aaregConsumer: AaregConsumer, private va
             }
             .map { arbeidsavtale ->
                 Stilling().apply {
-                    yrke = stillingsnavnFromKode(arbeidsavtale.yrke)
+                    yrke = stillingsnavnFromKode(arbeidsavtale.yrke, kodeverkBetydninger)
                     prosent = stillingsprosentWithMaxScale(arbeidsavtale.stillingsprosent)
                 }
             }
     }
 
-    private fun stillingsnavnFromKode(stillingskode: String): String {
-        val kodeverkBetydninger: KodeverkKoderBetydningerResponse = fellesKodeverkConsumer.kodeverkKoderBetydninger()
+    private fun stillingsnavnFromKode(stillingskode: String, kodeverkBetydninger: KodeverkKoderBetydningerResponse): String {
         val stillingsnavnFraFellesKodeverk = kodeverkBetydninger.betydninger[stillingskode]?.get(0)?.beskrivelser?.get("nb")?.tekst
         if (stillingsnavnFraFellesKodeverk == null) {
             log.error("Couldn't find navn for stillingskode: $stillingskode")

--- a/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidsgiverOppfolgingsplanControllerV2Test.kt
@@ -4,6 +4,7 @@ import no.nav.syfo.api.AbstractRessursTilgangTest
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.OpprettOppfolgingsplanRequest
 import no.nav.syfo.metric.Metrikk
 import no.nav.syfo.narmesteleder.NarmesteLederConsumer
+import no.nav.syfo.service.ArbeidsforholdService
 import no.nav.syfo.service.OppfolgingsplanService
 import no.nav.syfo.testhelper.OidcTestHelper.loggUtAlle
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_FNR
@@ -26,6 +27,9 @@ class ArbeidsgiverOppfolgingsplanControllerV2Test : AbstractRessursTilgangTest()
 
     @MockBean
     lateinit var oppfolgingsplanService: OppfolgingsplanService
+
+    @MockBean
+    lateinit var arbeidsforholdService: ArbeidsforholdService
 
     @MockBean
     lateinit var metrikk: Metrikk

--- a/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/api/v2/controller/ArbeidstakerOppfolgingsplanControllerV2Test.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.api.v2.controller
 import no.nav.syfo.api.AbstractRessursTilgangTest
 import no.nav.syfo.api.v2.domain.oppfolgingsplan.OpprettOppfolgingsplanRequest
 import no.nav.syfo.metric.Metrikk
+import no.nav.syfo.service.ArbeidsforholdService
 import no.nav.syfo.service.OppfolgingsplanService
 import no.nav.syfo.testhelper.OidcTestHelper.loggUtAlle
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_FNR
@@ -20,6 +21,9 @@ import javax.inject.Inject
 class ArbeidstakerOppfolgingsplanControllerV2Test : AbstractRessursTilgangTest() {
     @MockBean
     lateinit var oppfolgingsplanService: OppfolgingsplanService
+
+    @MockBean
+    lateinit var arbeidsforholdService: ArbeidsforholdService
 
     @MockBean
     lateinit var metrikk: Metrikk

--- a/src/test/kotlin/no/nav/syfo/api/v3/controller/ArbeidsforholdControllerV3Test.kt
+++ b/src/test/kotlin/no/nav/syfo/api/v3/controller/ArbeidsforholdControllerV3Test.kt
@@ -36,33 +36,37 @@ class ArbeidsforholdControllerV3Test : AbstractRessursTilgangTest() {
     @Value("\${oppfolgingsplan.frontend.client.id}")
     private lateinit var oppfolgingsplanClientId: String
 
-    val stilling = Stilling().yrke("Bilmekaniker").prosent(BigDecimal.TEN)
+    val stilling = Stilling().yrke("Bilmekaniker").prosent(BigDecimal.TEN).fom(LocalDate.now().minusYears(1)).tom(LocalDate.now())
 
     @Test
     fun narmesteLeder_ansatt_ok() {
         loggInnBrukerTokenX(contextHolder, LEDER_FNR, oppfolgingsplanClientId, tokenxIdp)
         `when`(brukertilgangConsumer.hasAccessToAnsatt(ARBEIDSTAKER_FNR)).thenReturn(true)
-        `when`(arbeidsforholdService.arbeidstakersFnrStillingerForOrgnummer(ARBEIDSTAKER_FNR, LocalDate.now(), VIRKSOMHETSNUMMER))
+        `when`(arbeidsforholdService.arbeidstakersStillingerForOrgnummer(ARBEIDSTAKER_FNR, VIRKSOMHETSNUMMER))
             .thenReturn(listOf(stilling))
-        val res: ResponseEntity<List<Arbeidsforhold>> = arbeidsforholdController.getArbeidsforhold(ARBEIDSTAKER_FNR, VIRKSOMHETSNUMMER, LocalDate.now())
+        val res: ResponseEntity<List<Arbeidsforhold>> = arbeidsforholdController.getArbeidsforhold(ARBEIDSTAKER_FNR, VIRKSOMHETSNUMMER)
         val body = res.body as List<Arbeidsforhold>
         val arbeidsforhold = body[0]
         assertEquals(200, res.statusCodeValue.toLong())
         assertEquals(stilling.yrke, arbeidsforhold.yrke)
         assertEquals(stilling.prosent, arbeidsforhold.prosent)
+        assertEquals(stilling.fom, arbeidsforhold.fom)
+        assertEquals(stilling.tom, arbeidsforhold.tom)
     }
 
     @Test
     fun narmesteLeder_self_ok() {
         loggInnBrukerTokenX(contextHolder, ARBEIDSTAKER_FNR, oppfolgingsplanClientId, tokenxIdp)
-        `when`(arbeidsforholdService.arbeidstakersFnrStillingerForOrgnummer(ARBEIDSTAKER_FNR, LocalDate.now(), VIRKSOMHETSNUMMER))
+        `when`(arbeidsforholdService.arbeidstakersStillingerForOrgnummer(ARBEIDSTAKER_FNR, VIRKSOMHETSNUMMER))
             .thenReturn(listOf(stilling))
-        val res: ResponseEntity<List<Arbeidsforhold>> = arbeidsforholdController.getArbeidsforhold(ARBEIDSTAKER_FNR, VIRKSOMHETSNUMMER, LocalDate.now())
+        val res: ResponseEntity<List<Arbeidsforhold>> = arbeidsforholdController.getArbeidsforhold(ARBEIDSTAKER_FNR, VIRKSOMHETSNUMMER)
         val body = res.body as List<Arbeidsforhold>
         val arbeidsforhold = body[0]
         assertEquals(200, res.statusCodeValue.toLong())
         assertEquals(stilling.yrke, arbeidsforhold.yrke)
         assertEquals(stilling.prosent, arbeidsforhold.prosent)
+        assertEquals(stilling.fom, arbeidsforhold.fom)
+        assertEquals(stilling.tom, arbeidsforhold.tom)
     }
 
     @Test
@@ -70,7 +74,7 @@ class ArbeidsforholdControllerV3Test : AbstractRessursTilgangTest() {
         loggInnBrukerTokenX(contextHolder, LEDER_FNR, oppfolgingsplanClientId, tokenxIdp)
         `when`(brukertilgangConsumer.hasAccessToAnsatt(ARBEIDSTAKER_FNR)).thenReturn(false)
 
-        val res: ResponseEntity<*> = arbeidsforholdController.getArbeidsforhold(ARBEIDSTAKER_FNR, VIRKSOMHETSNUMMER, LocalDate.now())
+        val res: ResponseEntity<*> = arbeidsforholdController.getArbeidsforhold(ARBEIDSTAKER_FNR, VIRKSOMHETSNUMMER)
         assertEquals(403, res.statusCodeValue.toLong())
     }
 }

--- a/src/test/kotlin/no/nav/syfo/service/ArbeidsforholdServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ArbeidsforholdServiceTest.kt
@@ -1,11 +1,7 @@
 package no.nav.syfo.service
 
-import no.nav.syfo.aareg.AaregConsumer
-import no.nav.syfo.aareg.AaregUtils
-import no.nav.syfo.aareg.Arbeidsforhold
-import no.nav.syfo.aareg.utils.AaregConsumerTestUtils
-import no.nav.syfo.aareg.utils.AaregConsumerTestUtils.YRKESKODE
-import no.nav.syfo.aareg.utils.AaregConsumerTestUtils.YRKESNAVN
+import no.nav.syfo.aareg.*
+import no.nav.syfo.aareg.utils.AaregConsumerTestUtils.*
 import no.nav.syfo.fellesKodeverk.*
 import no.nav.syfo.model.Stilling
 import no.nav.syfo.pdl.PdlConsumer
@@ -18,6 +14,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
+import java.time.LocalDate
 import java.time.LocalDate.now
 
 @RunWith(MockitoJUnitRunner::class)
@@ -42,19 +39,19 @@ class ArbeidsforholdServiceTest {
 
     @Test
     fun arbeidstakersStillingerForOrgnummerShouldReturnCorrectYrke() {
-        val arbeidsforholdList = listOf(AaregConsumerTestUtils.validArbeidsforhold())
+        val arbeidsforholdList = listOf(validArbeidsforhold())
 
         test_arbeidstakersStillingerForOrgnummer(arbeidsforholdList)
     }
 
     @Test
     fun arbeidstakersStillingerForOrgnummerShouldReturnCustomMessageIfNavnNotFound() {
-        val arbeidsforholdList = listOf(AaregConsumerTestUtils.validArbeidsforhold())
+        val arbeidsforholdList = listOf(validArbeidsforhold())
         `when`(fellesKodeverkConsumer.kodeverkKoderBetydninger()).thenReturn(fellesKodeverkResponseBodyWithWrongKode())
-        `when`(aaregConsumer.arbeidsforholdArbeidstaker(AaregConsumerTestUtils.AT_FNR)).thenReturn(arbeidsforholdList)
-        `when`(pdlConsumer.fnr(AaregConsumerTestUtils.AT_AKTORID)).thenReturn(AaregConsumerTestUtils.AT_FNR)
+        `when`(aaregConsumer.arbeidsforholdArbeidstaker(AT_FNR)).thenReturn(arbeidsforholdList)
+        `when`(pdlConsumer.fnr(AT_AKTORID)).thenReturn(AT_FNR)
         val actualStillingList =
-            arbeidsforholdService.arbeidstakersStillingerForOrgnummer(AaregConsumerTestUtils.AT_AKTORID, now(), AaregConsumerTestUtils.ORGNUMMER)
+            arbeidsforholdService.arbeidstakersStillingerForOrgnummer(AT_AKTORID, now(), ORGNUMMER)
 
         val stilling = actualStillingList[0]
         assertThat(stilling.yrke).isEqualTo("Ugyldig yrkeskode $STILLINGSKODE")
@@ -62,21 +59,21 @@ class ArbeidsforholdServiceTest {
 
     @Test
     fun arbeidstakersStillingerForOrgnummerShouldOnlyReturnStillingerWithTypeOrganization() {
-        val arbeidsforholdList = listOf(AaregConsumerTestUtils.validArbeidsforhold(), AaregConsumerTestUtils.arbeidsforholdTypePerson())
+        val arbeidsforholdList = listOf(validArbeidsforhold(), arbeidsforholdTypePerson())
 
         test_arbeidstakersStillingerForOrgnummer(arbeidsforholdList)
     }
 
     @Test
     fun arbeidstakersStillingerForOrgnummerShouldOnlyReturnStillingerValidOnDate() {
-        val arbeidsforholdList = listOf(AaregConsumerTestUtils.validArbeidsforhold(), AaregConsumerTestUtils.arbeidsforholdWithPassedDate())
+        val arbeidsforholdList = listOf(validArbeidsforhold(), arbeidsforholdWithPassedDate())
 
         test_arbeidstakersStillingerForOrgnummer(arbeidsforholdList)
     }
 
     @Test
     fun arbeidstakersStillingerForOrgnummerShouldOnlyReturnStillingerWithOrgnummer() {
-        val arbeidsforholdList = listOf(AaregConsumerTestUtils.validArbeidsforhold(), AaregConsumerTestUtils.arbeidsforholdWithWrongOrgnummer())
+        val arbeidsforholdList = listOf(validArbeidsforhold(), arbeidsforholdWithWrongOrgnummer())
 
         test_arbeidstakersStillingerForOrgnummer(arbeidsforholdList)
     }
@@ -84,31 +81,150 @@ class ArbeidsforholdServiceTest {
     @Test
     fun arbeidstakersStillingerForOrgnummerShouldReturnEmptyListWhenNoValidArbeidsforhold() {
         val arbeidsforholdList = listOf(
-            AaregConsumerTestUtils.arbeidsforholdTypePerson(),
-            AaregConsumerTestUtils.arbeidsforholdWithPassedDate(),
-            AaregConsumerTestUtils.arbeidsforholdWithWrongOrgnummer()
+            arbeidsforholdTypePerson(),
+            arbeidsforholdWithPassedDate(),
+            arbeidsforholdWithWrongOrgnummer()
         )
 
-        `when`(aaregConsumer.arbeidsforholdArbeidstaker(AaregConsumerTestUtils.AT_FNR)).thenReturn(arbeidsforholdList)
-        `when`(pdlConsumer.fnr(AaregConsumerTestUtils.AT_AKTORID)).thenReturn(AaregConsumerTestUtils.AT_FNR)
+        `when`(aaregConsumer.arbeidsforholdArbeidstaker(AT_FNR)).thenReturn(arbeidsforholdList)
+        `when`(pdlConsumer.fnr(AT_AKTORID)).thenReturn(AT_FNR)
 
-        val actualStillingList = arbeidsforholdService.arbeidstakersStillingerForOrgnummer(AaregConsumerTestUtils.AT_AKTORID, now(), AaregConsumerTestUtils.ORGNUMMER)
+        val actualStillingList = arbeidsforholdService.arbeidstakersStillingerForOrgnummer(AT_AKTORID, now(), ORGNUMMER)
 
         assertThat(actualStillingList).isEmpty()
     }
 
+    @Test
+    fun sholdMapArbeidsforholdWithOnlyOneArbeidsavtale() {
+        val startDate = now().minusYears(1)
+        val arbeidsforholdList = listOf(
+            validArbeidsforhold().apply {
+                ansettelsesperiode = ansettelsesperiode(startDate, null)
+                arbeidsavtaler =
+                    listOf(
+                        Arbeidsavtale()
+                            .yrke(YRKESKODE)
+                            .stillingsprosent(STILLINGSPROSENT)
+                            .gyldighetsperiode(
+                                Gyldighetsperiode()
+                                    .fom(startDate.withDayOfMonth(1).toString())
+                            )
+                    )
+            }
+        )
+        `when`(aaregConsumer.arbeidsforholdArbeidstaker(AT_FNR)).thenReturn(arbeidsforholdList)
+
+        val actualStillingList = arbeidsforholdService.arbeidstakersStillingerForOrgnummer(AT_FNR, ORGNUMMER)
+
+        assertThat(actualStillingList).isNotEmpty
+        val stilling1 = actualStillingList[0]
+        assertThat(stilling1.yrke).isEqualTo(YRKESNAVN_CAPITALIZED)
+        assertThat(stilling1.prosent).isEqualTo(AaregUtils.stillingsprosentWithMaxScale(STILLINGSPROSENT))
+        assertThat(stilling1.fom).isEqualTo(startDate)
+        assertThat(stilling1.tom).isNull()
+    }
+
+    @Test
+    fun sholdMapArbeidsforholdWithOnlyAvsluttetArbeidsavtale() {
+        val startDate = now().minusYears(1)
+        val stopDate = now().minusDays(1)
+        val arbeidsforholdList = listOf(
+            validArbeidsforhold().apply {
+                ansettelsesperiode = ansettelsesperiode(startDate, stopDate)
+                arbeidsavtaler =
+                    listOf(
+                        Arbeidsavtale()
+                            .yrke(YRKESKODE)
+                            .stillingsprosent(STILLINGSPROSENT)
+                            .gyldighetsperiode(
+                                Gyldighetsperiode()
+                                    .fom(startDate.withDayOfMonth(1).toString())
+                            )
+                    )
+            }
+        )
+        `when`(aaregConsumer.arbeidsforholdArbeidstaker(AT_FNR)).thenReturn(arbeidsforholdList)
+
+        val actualStillingList = arbeidsforholdService.arbeidstakersStillingerForOrgnummer(AT_FNR, ORGNUMMER)
+
+        assertThat(actualStillingList).isNotEmpty
+        val stilling1 = actualStillingList[0]
+        assertThat(stilling1.yrke).isEqualTo(YRKESNAVN_CAPITALIZED)
+        assertThat(stilling1.prosent).isEqualTo(AaregUtils.stillingsprosentWithMaxScale(STILLINGSPROSENT))
+        assertThat(stilling1.fom).isEqualTo(startDate)
+        assertThat(stilling1.tom).isEqualTo(stopDate)
+    }
+
+    @Test
+    fun sholdMapArbeidsforholdWithTwoArbeidsavtaler() {
+        val startDate = now().minusYears(1)
+        val stilling1StopDate = now().minusMonths(1).withDayOfMonth(1).minusDays(1)
+        val stilling2StartDate = now().minusMonths(1).withDayOfMonth(1)
+        val stilling2Stillingsprosent = 80.0
+        val arbeidsforholdList = listOf(
+            validArbeidsforhold().apply {
+                ansettelsesperiode = ansettelsesperiode(startDate, null)
+                arbeidsavtaler =
+                    listOf(
+                        Arbeidsavtale()
+                            .yrke(YRKESKODE)
+                            .stillingsprosent(STILLINGSPROSENT)
+                            .gyldighetsperiode(
+                                Gyldighetsperiode()
+                                    .fom(startDate.withDayOfMonth(1).toString())
+                                    .tom(stilling1StopDate.toString())
+                            ),
+                        Arbeidsavtale()
+                            .yrke("123")
+                            .stillingsprosent(stilling2Stillingsprosent)
+                            .gyldighetsperiode(
+                                Gyldighetsperiode()
+                                    .fom(stilling2StartDate.toString())
+                            )
+                    )
+            }
+        )
+        `when`(aaregConsumer.arbeidsforholdArbeidstaker(AT_FNR)).thenReturn(arbeidsforholdList)
+
+        val actualStillingList = arbeidsforholdService.arbeidstakersStillingerForOrgnummer(AT_FNR, ORGNUMMER)
+
+        assertThat(actualStillingList).isNotEmpty
+
+        val stilling1 = actualStillingList[0]
+        assertThat(stilling1.yrke).isEqualTo(YRKESNAVN_CAPITALIZED)
+        assertThat(stilling1.prosent).isEqualTo(AaregUtils.stillingsprosentWithMaxScale(STILLINGSPROSENT))
+        assertThat(stilling1.fom).isEqualTo(startDate)
+        assertThat(stilling1.tom).isEqualTo(stilling1StopDate)
+
+        val stilling2 = actualStillingList[1]
+        assertThat(stilling2.yrke).isEqualTo("Ugyldig yrkeskode 123")
+        assertThat(stilling2.prosent).isEqualTo(AaregUtils.stillingsprosentWithMaxScale(stilling2Stillingsprosent))
+        assertThat(stilling2.fom).isEqualTo(stilling2StartDate)
+        assertThat(stilling2.tom).isNull()
+
+    }
+
     private fun test_arbeidstakersStillingerForOrgnummer(arbeidsforholdList: List<Arbeidsforhold>) {
-        `when`(aaregConsumer.arbeidsforholdArbeidstaker(AaregConsumerTestUtils.AT_FNR)).thenReturn(arbeidsforholdList)
-        `when`(pdlConsumer.fnr(AaregConsumerTestUtils.AT_AKTORID)).thenReturn(AaregConsumerTestUtils.AT_FNR)
+        `when`(aaregConsumer.arbeidsforholdArbeidstaker(AT_FNR)).thenReturn(arbeidsforholdList)
+        `when`(pdlConsumer.fnr(AT_AKTORID)).thenReturn(AT_FNR)
         val actualStillingList =
-            arbeidsforholdService.arbeidstakersStillingerForOrgnummer(AaregConsumerTestUtils.AT_AKTORID, now(), AaregConsumerTestUtils.ORGNUMMER)
+            arbeidsforholdService.arbeidstakersStillingerForOrgnummer(AT_AKTORID, now(), ORGNUMMER)
         verifyStilling(actualStillingList)
     }
 
     private fun verifyStilling(stillingList: List<Stilling>) {
         assertThat(stillingList.size).isEqualTo(1)
         val stilling = stillingList[0]
-        assertThat(stilling.yrke).isEqualTo(AaregConsumerTestUtils.YRKESNAVN_CAPITALIZED)
-        assertThat(stilling.prosent).isEqualTo(AaregUtils.stillingsprosentWithMaxScale(AaregConsumerTestUtils.STILLINGSPROSENT))
+        assertThat(stilling.yrke).isEqualTo(YRKESNAVN_CAPITALIZED)
+        assertThat(stilling.prosent).isEqualTo(AaregUtils.stillingsprosentWithMaxScale(STILLINGSPROSENT))
+    }
+
+    private fun ansettelsesperiode(fom: LocalDate?, tom: LocalDate?): Ansettelsesperiode {
+        return Ansettelsesperiode()
+            .periode(
+                Periode()
+                    .fom(fom?.toString())
+                    .tom(tom?.toString())
+            )
     }
 }


### PR DESCRIPTION
Fetching av arbeidsforhold har vært litt problematisk fordi man hentet alle arbeidsforhold for hver eneste oppfølgingsplan. Nå hentes den sykmeldtes arbeidsforhold én gang i stedet, og det bedrer responstiden ganske mye.