### PR TITLE
Replace kodeverk with kodeverk-api

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -135,7 +135,7 @@ spec:
     - name: SYFOBRUKERTILGANG_ID
       value: dev-gcp:team-esyfo:syfobrukertilgang
     - name: FELLESKODEVERK_URL
-      value: https://kodeverk.nais.preprod.local/api/v1
+      value: https://kodeverk-api.nav.no/api/v1
     - name: SYFOSMREGISTER_URL
       value: https://smregister.intern.dev.nav.no
     - name: SYFOSMREGISTER_ID

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -131,7 +131,7 @@ spec:
     - name: SYFOOPPDFGEN_URL
       value: https://syfooppdfgen.intern.nav.no
     - name: FELLESKODEVERK_URL
-      value: https://kodeverk.nais.adeo.no/api/v1
+      value: https://kodeverk-api.nav.no/api/v1
     - name: SYFOSMREGISTER_URL
       value: https://smregister.intern.nav.no
     - name: SYFOSMREGISTER_ID

--- a/src/main/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumer.java
+++ b/src/main/java/no/nav/syfo/fellesKodeverk/FellesKodeverkConsumer.java
@@ -22,7 +22,7 @@ public class FellesKodeverkConsumer {
     private static final Logger LOG = getLogger(FellesKodeverkConsumer.class);
 
     private final Metrikk metric;
-    private final RestTemplate restTemplate;
+    private final RestTemplate restTemplateMedProxy;
     private final String url;
 
     public static final String NAV_CALL_ID_HEADER = "Nav-Call-Id";
@@ -31,11 +31,11 @@ public class FellesKodeverkConsumer {
     @Autowired
     public FellesKodeverkConsumer(
             Metrikk metric,
-            RestTemplate restTemplate,
+            RestTemplate restTemplateMedProxy,
             @Value("${felleskodeverk.url}") String url
     ) {
         this.metric = metric;
-        this.restTemplate = restTemplate;
+        this.restTemplateMedProxy = restTemplateMedProxy;
         this.url = url;
     }
 
@@ -44,7 +44,7 @@ public class FellesKodeverkConsumer {
         String kodeverkYrkerBetydningUrl = url + "/kodeverk/Yrker/koder/betydninger?spraak=nb";
 
         try {
-            ResponseEntity<KodeverkKoderBetydningerResponse> response = restTemplate.exchange(
+            ResponseEntity<KodeverkKoderBetydningerResponse> response = restTemplateMedProxy.exchange(
                     kodeverkYrkerBetydningUrl,
                     GET,
                     entity(),


### PR DESCRIPTION
Bruker kodeverk-api (ny versjon) i stedet for kodeverk

Har testet å tvangsgodkjenne en plan, og det ser ut til at stillingsbeskrivelsen kommer opp
<img width="1347" alt="image" src="https://github.com/navikt/syfooppfolgingsplanservice/assets/75254007/9b544fdb-652d-451b-a221-b1ebfee123cb">

Vises også i i modia:
<img width="716" alt="image" src="https://github.com/navikt/syfooppfolgingsplanservice/assets/75254007/cc2268cd-01e9-49c7-a5e6-b977eced4ba8">
