### PR TITLE
Remove vulnerable itext dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,7 +148,6 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus:1.16.5")
     implementation("net.logstash.logback:logstash-logback-encoder:8.1")
     implementation("commons-io:commons-io:2.22.0")
-    implementation("com.lowagie:itext:2.1.7")
     implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20220608.1")
     implementation("javax.inject:javax.inject:1")
     implementation("org.apache.pdfbox:pdfbox:2.0.25")


### PR DESCRIPTION
## Summary
- Remove direct dependency on vulnerable `com.lowagie:itext:2.1.7`
- Keep PDF generation on OpenPDF via `org.xhtmlrenderer:flying-saucer-pdf`

## Validation
- `dependencyInsight` confirms `com.lowagie:itext` is no longer present in `runtimeClasspath`
- `dependencyInsight` confirms `com.github.librepdf:openpdf:2.0.5` is still provided by `flying-saucer-pdf`
- `./gradlew test` could not complete locally because private NAV GitHub Packages returned `401 Unauthorized` with dummy credentials