### PR TITLE
Upgrade tomcat to 10.1.55 to patch vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,7 @@ dependencyManagement {
     }
 }
 
-extra["tomcat.version"] = "10.1.54"
+extra["tomcat.version"] = "10.1.55"
 
 dependencies {
     implementation(kotlin("stdlib"))


### PR DESCRIPTION
## Beskrivelse

Oppdaterer runtime dependency-overrides for å lukke Google Cloud CVE-funn for Tomcat og Netty uten å hoppe til større dependency-linjer.

## Endringer

- `build.gradle.kts`: oppgraderer `tomcat.version` fra `10.1.54` til `10.1.55`


## Issue

Ingen issue. Gjelder kritiske sårbarhetsfunn fra Google Cloud scanner.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil (`./gradlew --no-daemon build`)
- [x] Endringene er testet med `dependencyInsight` for `tomcat-embed-core`
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)****